### PR TITLE
Refactor/mltsa md add MD labeling and features workflows

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "h5py>=3.10",
   "numpy>=1.24",
   "scikit-learn>=1.4",
+  "torch>=2.11",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,10 @@ dependencies = [
 
 [project.optional-dependencies]
 test = ["pytest>=8,<10"]
+md = [
+  "matplotlib>=3.8",
+  "mdtraj>=1.10",
+]
 
 [project.scripts]
 mltsa = "mltsa.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
   "h5py>=3.10",
   "numpy>=1.24",
+  "scikit-learn>=1.4",
 ]
 
 [project.optional-dependencies]

--- a/src/mltsa/explain/__init__.py
+++ b/src/mltsa/explain/__init__.py
@@ -1,3 +1,17 @@
 """Explainability, attribution, and diagnostics tools for mltsa."""
 
-__all__: list[str] = []
+from .api import analyze
+from .global_mean import global_mean_importance
+from .native import native_importance
+from .permutation import permutation_importance
+from .plotting import plot_importances
+from .results import ExplanationResult
+
+__all__ = [
+    "ExplanationResult",
+    "analyze",
+    "global_mean_importance",
+    "native_importance",
+    "permutation_importance",
+    "plot_importances",
+]

--- a/src/mltsa/explain/api.py
+++ b/src/mltsa/explain/api.py
@@ -1,0 +1,38 @@
+"""Public dispatcher for explainability methods."""
+
+from __future__ import annotations
+
+from .global_mean import global_mean_importance
+from .native import native_importance
+from .permutation import permutation_importance
+from .results import ExplanationResult
+
+
+def analyze(
+    model: object,
+    *,
+    method: str = "native",
+    X: object | None = None,
+    y: object | None = None,
+    feature_names: list[str] | tuple[str, ...] | None = None,
+    **kwargs: object,
+) -> ExplanationResult:
+    """Dispatch to a supported explainability method."""
+
+    normalized = method.strip().lower().replace("-", "_").replace(" ", "_")
+
+    if normalized == "native":
+        return native_importance(model, feature_names=feature_names)
+    if normalized == "permutation":
+        if X is None or y is None:
+            raise ValueError("permutation analysis requires both X and y.")
+        return permutation_importance(model, X, y, feature_names=feature_names, **kwargs)
+    if normalized in {"global_mean", "globalmean"}:
+        if X is None or y is None:
+            raise ValueError("global mean analysis requires both X and y.")
+        return global_mean_importance(model, X, y, feature_names=feature_names, **kwargs)
+
+    raise ValueError(f"Unsupported analysis method {method!r}.")
+
+
+__all__ = ["analyze"]

--- a/src/mltsa/explain/global_mean.py
+++ b/src/mltsa/explain/global_mean.py
@@ -1,0 +1,53 @@
+"""Global-mean feature perturbation importance."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .results import (
+    ExplanationResult,
+    coerce_feature_names,
+    ensure_feature_matrix,
+    ensure_target_vector,
+    infer_model_name,
+    score_estimator,
+    scoring_name,
+)
+
+
+def global_mean_importance(
+    model: object,
+    X: object,
+    y: object,
+    *,
+    feature_names: list[str] | tuple[str, ...] | None = None,
+    scoring: str | None = None,
+) -> ExplanationResult:
+    """Measure importance by replacing each feature with its global mean."""
+
+    matrix = ensure_feature_matrix(X)
+    targets = ensure_target_vector(y, matrix.shape[0])
+    baseline = score_estimator(model, matrix, targets, scoring)
+    feature_means = matrix.mean(axis=0)
+
+    perturbed_scores = np.empty(matrix.shape[1], dtype=np.float64)
+    for feature_index, feature_mean in enumerate(feature_means):
+        perturbed = matrix.copy()
+        perturbed[:, feature_index] = feature_mean
+        perturbed_scores[feature_index] = score_estimator(model, perturbed, targets, scoring)
+
+    importances = baseline - perturbed_scores
+    names = coerce_feature_names(feature_names, int(importances.shape[0]))
+    return ExplanationResult(
+        method="global_mean",
+        importances=importances,
+        feature_names=names,
+        baseline_score=baseline,
+        perturbed_scores=perturbed_scores,
+        score_deltas=importances.copy(),
+        model_name=infer_model_name(model),
+        metadata={"scoring": scoring_name(scoring), "replacement": "global_mean"},
+    )
+
+
+__all__ = ["global_mean_importance"]

--- a/src/mltsa/explain/native.py
+++ b/src/mltsa/explain/native.py
@@ -1,0 +1,38 @@
+"""Native feature importance helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .results import ExplanationResult, coerce_feature_names, infer_model_name, resolve_estimator
+
+
+def native_importance(model: object, *, feature_names: list[str] | tuple[str, ...] | None = None) -> ExplanationResult:
+    """Extract native feature importance from a fitted model when available."""
+
+    estimator = resolve_estimator(model)
+
+    if hasattr(estimator, "feature_importances_"):
+        importances = np.asarray(estimator.feature_importances_, dtype=np.float64)
+        source = "feature_importances_"
+    elif hasattr(estimator, "coef_"):
+        coefficients = np.asarray(estimator.coef_, dtype=np.float64)
+        importances = np.abs(coefficients)
+        if importances.ndim > 1:
+            importances = importances.mean(axis=0)
+        source = "coef_"
+    else:
+        raise ValueError("The provided model does not expose native feature importances.")
+
+    names = coerce_feature_names(feature_names, int(importances.shape[0]))
+    return ExplanationResult(
+        method="native",
+        importances=importances,
+        feature_names=names,
+        score_deltas=importances.copy(),
+        model_name=infer_model_name(model),
+        metadata={"source": source},
+    )
+
+
+__all__ = ["native_importance"]

--- a/src/mltsa/explain/permutation.py
+++ b/src/mltsa/explain/permutation.py
@@ -1,0 +1,69 @@
+"""Permutation importance helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+from sklearn.inspection import permutation_importance as sklearn_permutation_importance
+
+from .results import (
+    ExplanationResult,
+    coerce_feature_names,
+    ensure_feature_matrix,
+    ensure_target_vector,
+    infer_model_name,
+    resolve_estimator,
+    score_estimator,
+    scoring_name,
+)
+
+
+def permutation_importance(
+    model: object,
+    X: object,
+    y: object,
+    *,
+    feature_names: list[str] | tuple[str, ...] | None = None,
+    scoring: str | None = None,
+    n_repeats: int = 10,
+    random_state: int = 0,
+    n_jobs: int | None = None,
+) -> ExplanationResult:
+    """Compute permutation importance for a fitted model."""
+
+    matrix = ensure_feature_matrix(X)
+    targets = ensure_target_vector(y, matrix.shape[0])
+    estimator = resolve_estimator(model)
+    baseline = score_estimator(estimator, matrix, targets, scoring)
+    permutation = sklearn_permutation_importance(
+        estimator,
+        matrix,
+        targets,
+        scoring=scoring,
+        n_repeats=n_repeats,
+        random_state=random_state,
+        n_jobs=n_jobs,
+    )
+
+    importances = np.asarray(permutation.importances_mean, dtype=np.float64)
+    std = np.asarray(permutation.importances_std, dtype=np.float64)
+    perturbed_scores = baseline - importances
+    names = coerce_feature_names(feature_names, int(importances.shape[0]))
+
+    return ExplanationResult(
+        method="permutation",
+        importances=importances,
+        feature_names=names,
+        baseline_score=baseline,
+        perturbed_scores=perturbed_scores,
+        score_deltas=importances.copy(),
+        std=std,
+        model_name=infer_model_name(model),
+        metadata={
+            "scoring": scoring_name(scoring),
+            "n_repeats": int(n_repeats),
+            "random_state": int(random_state),
+        },
+    )
+
+
+__all__ = ["permutation_importance"]

--- a/src/mltsa/explain/plotting.py
+++ b/src/mltsa/explain/plotting.py
@@ -1,0 +1,42 @@
+"""Plotting helpers for explanation results."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .results import ExplanationResult
+
+
+def plot_importances(
+    result: ExplanationResult,
+    *,
+    top_n: int | None = None,
+    sort: bool = True,
+    ax: Any | None = None,
+) -> Any:
+    """Plot feature importances for an explanation result."""
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError("matplotlib is required for explanation plotting helpers.") from exc
+
+    axis = ax if ax is not None else plt.subplots()[1]
+    indices = np.arange(result.n_features)
+    if sort:
+        indices = result.ranked_indices
+    if top_n is not None:
+        indices = indices[:top_n]
+
+    labels = [result.feature_names[index] for index in indices]
+    values = result.importances[indices]
+    axis.bar(np.arange(len(indices)), values)
+    axis.set_xticks(np.arange(len(indices)), labels, rotation=45, ha="right")
+    axis.set_ylabel("importance")
+    axis.set_title(f"{result.method.replace('_', ' ').title()} Importance")
+    return axis
+
+
+__all__ = ["plot_importances"]

--- a/src/mltsa/explain/results.py
+++ b/src/mltsa/explain/results.py
@@ -1,0 +1,182 @@
+"""Shared result type and persistence for explainability analyses."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+import h5py
+import numpy as np
+from sklearn.metrics import get_scorer
+
+from mltsa.io.h5 import create_appendable_group, ensure_group, open_h5, replace_dataset, write_utf8_array
+from mltsa.io.schema import ensure_results_layout, results_experiment_path
+from mltsa.synthetic.base import JSONValue, as_float_array
+
+
+@dataclass(slots=True)
+class ExplanationResult:
+    """Common result object returned by all explainability methods."""
+
+    method: str
+    importances: np.ndarray
+    feature_names: tuple[str, ...]
+    baseline_score: float | None = None
+    perturbed_scores: np.ndarray | None = None
+    score_deltas: np.ndarray | None = None
+    std: np.ndarray | None = None
+    model_name: str | None = None
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize result arrays and validate feature-level shapes."""
+
+        self.importances = as_float_array(self.importances)
+        self.feature_names = tuple(self.feature_names)
+        self.metadata = dict(self.metadata)
+
+        if self.importances.ndim != 1:
+            raise ValueError("importances must be one-dimensional.")
+        if len(self.feature_names) != self.importances.shape[0]:
+            raise ValueError("feature_names length must match importances length.")
+
+        if self.perturbed_scores is not None:
+            self.perturbed_scores = as_float_array(self.perturbed_scores)
+            if self.perturbed_scores.shape != self.importances.shape:
+                raise ValueError("perturbed_scores must match importances shape.")
+
+        if self.score_deltas is not None:
+            self.score_deltas = as_float_array(self.score_deltas)
+            if self.score_deltas.shape != self.importances.shape:
+                raise ValueError("score_deltas must match importances shape.")
+
+        if self.std is not None:
+            self.std = as_float_array(self.std)
+            if self.std.shape != self.importances.shape:
+                raise ValueError("std must match importances shape.")
+
+        if self.baseline_score is not None:
+            self.baseline_score = float(self.baseline_score)
+
+    @property
+    def n_features(self) -> int:
+        """Return the number of analyzed features."""
+
+        return int(self.importances.shape[0])
+
+    @property
+    def ranked_indices(self) -> np.ndarray:
+        """Return feature indices sorted by descending importance."""
+
+        return np.argsort(self.importances)[::-1]
+
+    def save(self, path: str | Path, *, experiment_id: str = "default") -> str:
+        """Append this explanation result to an HDF5 results file."""
+
+        file_path = Path(path)
+        with open_h5(file_path, "a") as handle:
+            ensure_results_layout(handle)
+            experiment = ensure_group(handle, results_experiment_path(experiment_id), attrs={"kind": "explain"})
+            explanation_group = create_appendable_group(experiment, "explanations", prefix="explanation", width=4)
+            explanation_group.attrs["method"] = self.method
+            explanation_group.attrs["model_name"] = self.model_name or ""
+            explanation_group.attrs["metadata_json"] = json.dumps(self.metadata, sort_keys=True)
+            if self.baseline_score is not None:
+                explanation_group.attrs["baseline_score"] = self.baseline_score
+
+            replace_dataset(explanation_group, "importances", self.importances)
+            write_utf8_array(explanation_group, "feature_names", self.feature_names, overwrite=True)
+
+            if self.perturbed_scores is not None:
+                replace_dataset(explanation_group, "perturbed_scores", self.perturbed_scores)
+            if self.score_deltas is not None:
+                replace_dataset(explanation_group, "score_deltas", self.score_deltas)
+            if self.std is not None:
+                replace_dataset(explanation_group, "std", self.std)
+
+            return explanation_group.name
+
+
+def coerce_feature_names(feature_names: list[str] | tuple[str, ...] | None, n_features: int) -> tuple[str, ...]:
+    """Return user-provided feature names or generate fallback names."""
+
+    if feature_names is None:
+        return tuple(f"feature_{index:03d}" for index in range(n_features))
+
+    normalized = tuple(str(name) for name in feature_names)
+    if len(normalized) != n_features:
+        raise ValueError("feature_names length must match the number of features.")
+    return normalized
+
+
+def resolve_estimator(model: Any) -> Any:
+    """Unwrap mltsa model wrappers while accepting raw sklearn estimators."""
+
+    if hasattr(model, "model_name") and hasattr(model, "estimator"):
+        return model.estimator
+    return model
+
+
+def infer_model_name(model: Any) -> str:
+    """Infer a user-facing model name from a wrapper or sklearn estimator."""
+
+    if hasattr(model, "model_name"):
+        return str(model.model_name)
+    estimator = resolve_estimator(model)
+    return type(estimator).__name__
+
+
+def ensure_feature_matrix(X: Any) -> np.ndarray:
+    """Convert input data to a 2D float feature matrix."""
+
+    matrix = np.asarray(X, dtype=np.float64)
+    if matrix.ndim != 2:
+        raise ValueError("X must have shape (n_samples, n_features).")
+    return matrix
+
+
+def ensure_target_vector(y: Any, n_samples: int) -> np.ndarray:
+    """Convert targets to a 1D array matching the sample count."""
+
+    targets = np.asarray(y)
+    if targets.ndim != 1:
+        raise ValueError("y must be one-dimensional.")
+    if targets.shape[0] != n_samples:
+        raise ValueError("y length must match the number of samples in X.")
+    return targets
+
+
+def score_estimator(model: Any, X: np.ndarray, y: np.ndarray, scoring: str | Callable[[Any, np.ndarray, np.ndarray], float] | None) -> float:
+    """Score an estimator using its own score method or a custom scoring rule."""
+
+    estimator = resolve_estimator(model)
+    if scoring is None:
+        return float(estimator.score(X, y))
+    if isinstance(scoring, str):
+        scorer = get_scorer(scoring)
+        return float(scorer(estimator, X, y))
+    return float(scoring(estimator, X, y))
+
+
+def scoring_name(scoring: str | Callable[[Any, np.ndarray, np.ndarray], float] | None) -> str:
+    """Return a stable scoring description for result metadata."""
+
+    if scoring is None:
+        return "estimator.score"
+    if isinstance(scoring, str):
+        return scoring
+    return getattr(scoring, "__name__", "callable")
+
+
+__all__ = [
+    "ExplanationResult",
+    "coerce_feature_names",
+    "ensure_feature_matrix",
+    "ensure_target_vector",
+    "infer_model_name",
+    "resolve_estimator",
+    "score_estimator",
+    "scoring_name",
+]

--- a/src/mltsa/md/__init__.py
+++ b/src/mltsa/md/__init__.py
@@ -1,3 +1,5 @@
 """Molecular dynamics specific workflows for mltsa."""
 
-__all__: list[str] = []
+from .label import LabelingResult, TrajectoryLabelEntry, label_trajectories
+
+__all__ = ["LabelingResult", "TrajectoryLabelEntry", "label_trajectories"]

--- a/src/mltsa/md/__init__.py
+++ b/src/mltsa/md/__init__.py
@@ -1,5 +1,13 @@
 """Molecular dynamics specific workflows for mltsa."""
 
+from .featurize import MDFeatureDataset, featurize_dataset, load_dataset
 from .label import LabelingResult, TrajectoryLabelEntry, label_trajectories
 
-__all__ = ["LabelingResult", "TrajectoryLabelEntry", "label_trajectories"]
+__all__ = [
+    "LabelingResult",
+    "MDFeatureDataset",
+    "TrajectoryLabelEntry",
+    "featurize_dataset",
+    "label_trajectories",
+    "load_dataset",
+]

--- a/src/mltsa/md/features/__init__.py
+++ b/src/mltsa/md/features/__init__.py
@@ -1,5 +1,23 @@
 """Feature-level helpers for molecular dynamics workflows."""
 
+from .base import FeatureComputation, MDFeatureDataset
+from .contacts import contact_map
+from .distances import all_ligand_protein_distances, bubble_distances, closest_residue_distances
+from .pca import pca_xyz
 from .rules import RuleEvaluation, WaterMetadata, evaluate_rule, gather_nearby_waters
+from .waters import read_stored_water_atom_indices
 
-__all__ = ["RuleEvaluation", "WaterMetadata", "evaluate_rule", "gather_nearby_waters"]
+__all__ = [
+    "FeatureComputation",
+    "MDFeatureDataset",
+    "RuleEvaluation",
+    "WaterMetadata",
+    "all_ligand_protein_distances",
+    "bubble_distances",
+    "closest_residue_distances",
+    "contact_map",
+    "evaluate_rule",
+    "gather_nearby_waters",
+    "pca_xyz",
+    "read_stored_water_atom_indices",
+]

--- a/src/mltsa/md/features/__init__.py
+++ b/src/mltsa/md/features/__init__.py
@@ -1,0 +1,5 @@
+"""Feature-level helpers for molecular dynamics workflows."""
+
+from .rules import RuleEvaluation, WaterMetadata, evaluate_rule, gather_nearby_waters
+
+__all__ = ["RuleEvaluation", "WaterMetadata", "evaluate_rule", "gather_nearby_waters"]

--- a/src/mltsa/md/features/base.py
+++ b/src/mltsa/md/features/base.py
@@ -1,0 +1,321 @@
+"""Shared types and helpers for MD feature extraction."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from mltsa.synthetic.base import JSONValue, as_float_array, as_int_array, clone_json
+
+from .rules import WATER_RESIDUE_NAMES
+
+FloatArray: TypeAlias = NDArray[np.float64]
+IntArray: TypeAlias = NDArray[np.int64]
+
+FEATURE_SET_SCHEMA = "mltsa.md.features"
+FEATURE_SET_SCHEMA_VERSION = 1
+STATE_ORDER = ("IN", "OUT", "TS")
+STATE_TO_INT = {label: index for index, label in enumerate(STATE_ORDER)}
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureComputation:
+    """Feature values computed for one trajectory."""
+
+    feature_type: str
+    values: FloatArray
+    feature_names: tuple[str, ...]
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize computed arrays and validate feature dimensions."""
+
+        object.__setattr__(self, "values", as_float_array(self.values))
+        object.__setattr__(self, "feature_names", tuple(self.feature_names))
+        object.__setattr__(self, "metadata", clone_json(self.metadata))
+
+        if self.values.ndim != 2:
+            raise ValueError("Feature values must have shape (n_frames, n_features).")
+        if self.values.shape[1] != len(self.feature_names):
+            raise ValueError("feature_names length must match the feature dimension of values.")
+        if len(set(self.feature_names)) != len(self.feature_names):
+            raise ValueError("feature_names must be unique within one feature computation.")
+
+
+@dataclass(slots=True)
+class MDFeatureDataset:
+    """Loaded MD feature dataset for one selected feature set."""
+
+    feature_set: str
+    feature_type: str
+    X: FloatArray
+    y: IntArray
+    state_labels: tuple[str, ...]
+    feature_names: tuple[str, ...]
+    replica_ids: tuple[str, ...]
+    trajectory_paths: tuple[str, ...]
+    topology_paths: tuple[str, ...]
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+    processed_replica_ids: tuple[str, ...] = ()
+    skipped_replica_ids: tuple[str, ...] = ()
+    overwritten_replica_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Normalize arrays and validate dataset consistency."""
+
+        self.X = as_float_array(self.X)
+        self.y = as_int_array(self.y)
+        self.state_labels = tuple(self.state_labels)
+        self.feature_names = tuple(self.feature_names)
+        self.replica_ids = tuple(self.replica_ids)
+        self.trajectory_paths = tuple(self.trajectory_paths)
+        self.topology_paths = tuple(self.topology_paths)
+        self.metadata = clone_json(self.metadata)
+        self.processed_replica_ids = tuple(self.processed_replica_ids)
+        self.skipped_replica_ids = tuple(self.skipped_replica_ids)
+        self.overwritten_replica_ids = tuple(self.overwritten_replica_ids)
+
+        if self.X.ndim != 3:
+            raise ValueError("X must have shape (n_replicas, n_frames, n_features).")
+        if self.X.shape[0] != self.y.shape[0]:
+            raise ValueError("y length must match the number of replicas in X.")
+        if self.X.shape[0] != len(self.state_labels):
+            raise ValueError("state_labels length must match the number of replicas in X.")
+        if self.X.shape[0] != len(self.replica_ids):
+            raise ValueError("replica_ids length must match the number of replicas in X.")
+        if self.X.shape[0] != len(self.trajectory_paths):
+            raise ValueError("trajectory_paths length must match the number of replicas in X.")
+        if self.X.shape[0] != len(self.topology_paths):
+            raise ValueError("topology_paths length must match the number of replicas in X.")
+        if self.X.shape[2] != len(self.feature_names):
+            raise ValueError("feature_names length must match the feature dimension of X.")
+
+    @property
+    def n_replicas(self) -> int:
+        """Number of stored MD replicas."""
+
+        return int(self.X.shape[0])
+
+    @property
+    def n_frames(self) -> int:
+        """Number of time steps per replica."""
+
+        return int(self.X.shape[1])
+
+    @property
+    def n_features(self) -> int:
+        """Number of features per time step."""
+
+        return int(self.X.shape[2])
+
+
+def normalize_feature_type(value: str) -> str:
+    """Canonicalize a user-provided feature-family name."""
+
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    supported = {
+        "closest_residue_distances",
+        "all_ligand_protein_distances",
+        "bubble_distances",
+        "contact_map",
+        "pca_xyz",
+    }
+    if normalized not in supported:
+        raise ValueError(f"Unsupported MD feature type {value!r}.")
+    return normalized
+
+
+def validate_replica_id(value: str) -> str:
+    """Reject empty or nested replica identifiers."""
+
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError("replica ids must not be empty.")
+    if "/" in cleaned:
+        raise ValueError("replica ids must not contain '/'.")
+    return cleaned
+
+
+def normalize_path(path: str | Path) -> str:
+    """Normalize a filesystem path for metadata identity checks."""
+
+    return Path(path).resolve(strict=False).as_posix().casefold()
+
+
+def state_to_int(label: str) -> int:
+    """Map a state label to a stable integer code."""
+
+    normalized = str(label).strip().upper()
+    if normalized not in STATE_TO_INT:
+        raise ValueError(f"Unsupported MD state label {label!r}.")
+    return int(STATE_TO_INT[normalized])
+
+
+def select_atom_indices(topology: Any, selection: str) -> IntArray:
+    """Resolve a topology selection string into atom indices."""
+
+    indices = np.asarray(topology.select(selection), dtype=np.int64)
+    if indices.ndim != 1 or indices.size == 0:
+        raise ValueError(f"Selection {selection!r} did not resolve to any atoms.")
+    return indices
+
+
+def non_water_atom_indices(topology: Any) -> IntArray:
+    """Return all atom indices that do not belong to water residues."""
+
+    indices = [
+        int(atom.index)
+        for atom in topology.atoms
+        if not is_water_residue(atom.residue)
+    ]
+    if not indices:
+        raise ValueError("Topology does not contain any non-water atoms.")
+    return np.asarray(indices, dtype=np.int64)
+
+
+def unique_indices(*arrays: np.ndarray | tuple[int, ...] | list[int]) -> IntArray:
+    """Merge one or more index collections into a sorted unique array."""
+
+    merged: list[int] = []
+    for values in arrays:
+        merged.extend(int(value) for value in np.asarray(values, dtype=np.int64).tolist())
+    if not merged:
+        return np.empty(0, dtype=np.int64)
+    return np.asarray(sorted(set(merged)), dtype=np.int64)
+
+
+def without_indices(indices: np.ndarray, excluded: np.ndarray) -> IntArray:
+    """Return ``indices`` with any ``excluded`` values removed."""
+
+    if indices.size == 0:
+        return np.empty(0, dtype=np.int64)
+    if excluded.size == 0:
+        return np.asarray(indices, dtype=np.int64)
+    mask = ~np.isin(indices, excluded)
+    return np.asarray(indices[mask], dtype=np.int64)
+
+
+def group_atom_indices_by_residue(topology: Any, atom_indices: np.ndarray) -> list[tuple[Any, IntArray]]:
+    """Group selected atom indices by residue while preserving topology order."""
+
+    groups: dict[int, tuple[Any, list[int]]] = {}
+    order: list[int] = []
+    selected = {int(index) for index in np.asarray(atom_indices, dtype=np.int64).tolist()}
+
+    for atom in topology.atoms:
+        atom_index = int(atom.index)
+        if atom_index not in selected:
+            continue
+        residue = atom.residue
+        key = id(residue)
+        if key not in groups:
+            groups[key] = (residue, [])
+            order.append(key)
+        groups[key][1].append(atom_index)
+
+    return [
+        (groups[key][0], np.asarray(groups[key][1], dtype=np.int64))
+        for key in order
+    ]
+
+
+def pairwise_distances(xyz: np.ndarray, left_indices: np.ndarray, right_indices: np.ndarray) -> FloatArray:
+    """Compute frame-wise distances for all left/right atom-index combinations."""
+
+    left = np.asarray(left_indices, dtype=np.int64)
+    right = np.asarray(right_indices, dtype=np.int64)
+    if left.size == 0 or right.size == 0:
+        raise ValueError("Distance features require at least one atom on both sides.")
+
+    left_xyz = np.asarray(xyz[:, left, :], dtype=np.float64)[:, :, None, :]
+    right_xyz = np.asarray(xyz[:, right, :], dtype=np.float64)[:, None, :, :]
+    return np.linalg.norm(left_xyz - right_xyz, axis=3).reshape(int(xyz.shape[0]), left.size * right.size)
+
+
+def min_group_distance_series(xyz: np.ndarray, left_indices: np.ndarray, right_indices: np.ndarray) -> FloatArray:
+    """Compute the minimum distance between two atom groups per frame."""
+
+    left = np.asarray(left_indices, dtype=np.int64)
+    right = np.asarray(right_indices, dtype=np.int64)
+    if left.size == 0 or right.size == 0:
+        raise ValueError("Minimum group distances require non-empty atom groups.")
+
+    left_xyz = np.asarray(xyz[:, left, :], dtype=np.float64)[:, :, None, :]
+    right_xyz = np.asarray(xyz[:, right, :], dtype=np.float64)[:, None, :, :]
+    return np.linalg.norm(left_xyz - right_xyz, axis=3).min(axis=(1, 2))
+
+
+def atom_label(atom: Any) -> str:
+    """Build a readable stable atom label for feature names."""
+
+    residue = atom.residue
+    return f"{residue_label(residue)}:{atom_name(atom)}{int(atom.index):03d}"
+
+
+def residue_label(residue: Any) -> str:
+    """Build a readable stable residue label for feature names."""
+
+    return f"{residue_name(residue)}{residue_id(residue):03d}"
+
+
+def atom_name(atom: Any) -> str:
+    """Return a normalized atom name."""
+
+    return str(getattr(atom, "name", "X")).strip() or "X"
+
+
+def residue_name(residue: Any) -> str:
+    """Return a normalized residue name."""
+
+    return str(getattr(residue, "name", "UNK")).strip() or "UNK"
+
+
+def residue_id(residue: Any) -> int:
+    """Return a stable residue identifier when available."""
+
+    if hasattr(residue, "resSeq"):
+        return int(residue.resSeq)
+    if hasattr(residue, "index"):
+        return int(residue.index)
+    return 0
+
+
+def is_water_residue(residue: Any) -> bool:
+    """Return ``True`` when a residue looks like water."""
+
+    if bool(getattr(residue, "is_water", False)):
+        return True
+    return residue_name(residue).upper() in WATER_RESIDUE_NAMES
+
+
+__all__ = [
+    "FEATURE_SET_SCHEMA",
+    "FEATURE_SET_SCHEMA_VERSION",
+    "FeatureComputation",
+    "FloatArray",
+    "IntArray",
+    "MDFeatureDataset",
+    "STATE_ORDER",
+    "STATE_TO_INT",
+    "atom_label",
+    "atom_name",
+    "group_atom_indices_by_residue",
+    "is_water_residue",
+    "min_group_distance_series",
+    "non_water_atom_indices",
+    "normalize_feature_type",
+    "normalize_path",
+    "pairwise_distances",
+    "residue_id",
+    "residue_label",
+    "residue_name",
+    "select_atom_indices",
+    "state_to_int",
+    "unique_indices",
+    "validate_replica_id",
+    "without_indices",
+]

--- a/src/mltsa/md/features/contacts.py
+++ b/src/mltsa/md/features/contacts.py
@@ -1,0 +1,47 @@
+"""Contact-map feature helpers for MD trajectories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .base import FeatureComputation
+from .distances import all_ligand_protein_distances
+
+
+def contact_map(
+    topology: Any,
+    xyz: np.ndarray,
+    *,
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    contact_threshold: float = 0.45,
+    water_atom_indices: tuple[int, ...] = (),
+) -> FeatureComputation:
+    """Compute a binary ligand contact map using an atom-distance threshold."""
+
+    if contact_threshold <= 0.0:
+        raise ValueError("contact_threshold must be greater than 0.")
+
+    distances = all_ligand_protein_distances(
+        topology,
+        xyz,
+        ligand_selection=ligand_selection,
+        protein_selection=protein_selection,
+        water_atom_indices=water_atom_indices,
+    )
+    contacts = (distances.values <= float(contact_threshold)).astype(np.float64)
+
+    return FeatureComputation(
+        feature_type="contact_map",
+        values=contacts,
+        feature_names=tuple(name.replace("distance:", "contact:", 1) for name in distances.feature_names),
+        metadata={
+            **distances.metadata,
+            "contact_threshold": float(contact_threshold),
+        },
+    )
+
+
+__all__ = ["contact_map"]

--- a/src/mltsa/md/features/distances.py
+++ b/src/mltsa/md/features/distances.py
@@ -1,0 +1,186 @@
+"""Distance-based MD feature families."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .base import (
+    FeatureComputation,
+    atom_label,
+    group_atom_indices_by_residue,
+    min_group_distance_series,
+    pairwise_distances,
+    residue_label,
+    select_atom_indices,
+    unique_indices,
+    without_indices,
+)
+
+
+def closest_residue_distances(
+    topology: Any,
+    xyz: np.ndarray,
+    *,
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    water_atom_indices: tuple[int, ...] = (),
+) -> FeatureComputation:
+    """Compute the closest ligand-to-residue distance for each selected residue."""
+
+    ligand_indices = select_atom_indices(topology, ligand_selection)
+    protein_indices = select_atom_indices(topology, protein_selection)
+    residue_groups = group_atom_indices_by_residue(topology, protein_indices)
+
+    water_indices = np.asarray(water_atom_indices, dtype=np.int64)
+    water_group_count = 0
+    if water_indices.size:
+        water_groups = group_atom_indices_by_residue(topology, water_indices)
+        water_group_count = len(water_groups)
+        residue_groups.extend(water_groups)
+
+    if not residue_groups:
+        raise ValueError("closest_residue_distances did not find any partner residues.")
+
+    values = np.empty((int(xyz.shape[0]), len(residue_groups)), dtype=np.float64)
+    feature_names: list[str] = []
+
+    for column, (residue, residue_indices) in enumerate(residue_groups):
+        values[:, column] = min_group_distance_series(xyz, ligand_indices, residue_indices)
+        feature_names.append(f"closest_residue:{residue_label(residue)}")
+
+    return FeatureComputation(
+        feature_type="closest_residue_distances",
+        values=values,
+        feature_names=tuple(feature_names),
+        metadata={
+            "ligand_selection": ligand_selection,
+            "protein_selection": protein_selection,
+            "residue_count": len(residue_groups),
+            "water_feature_count": water_group_count,
+        },
+    )
+
+
+def all_ligand_protein_distances(
+    topology: Any,
+    xyz: np.ndarray,
+    *,
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    water_atom_indices: tuple[int, ...] = (),
+) -> FeatureComputation:
+    """Compute all ligand-to-partner atom distances across the trajectory."""
+
+    ligand_indices = select_atom_indices(topology, ligand_selection)
+    partner_indices = _resolve_partner_indices(
+        topology=topology,
+        ligand_indices=ligand_indices,
+        protein_selection=protein_selection,
+        water_atom_indices=water_atom_indices,
+    )
+    values = pairwise_distances(xyz, ligand_indices, partner_indices)
+
+    return FeatureComputation(
+        feature_type="all_ligand_protein_distances",
+        values=values,
+        feature_names=_pair_feature_names(topology, ligand_indices, partner_indices, prefix="distance"),
+        metadata={
+            "ligand_selection": ligand_selection,
+            "protein_selection": protein_selection,
+            "ligand_atom_count": int(ligand_indices.size),
+            "partner_atom_count": int(partner_indices.size),
+            "water_atom_count": int(np.asarray(water_atom_indices, dtype=np.int64).size),
+        },
+    )
+
+
+def bubble_distances(
+    topology: Any,
+    xyz: np.ndarray,
+    *,
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    bubble_cutoff: float = 0.6,
+    water_atom_indices: tuple[int, ...] = (),
+) -> FeatureComputation:
+    """Compute ligand distances to nearby atoms in a first-frame distance bubble."""
+
+    if bubble_cutoff <= 0.0:
+        raise ValueError("bubble_cutoff must be greater than 0.")
+
+    ligand_indices = select_atom_indices(topology, ligand_selection)
+    protein_indices = without_indices(select_atom_indices(topology, protein_selection), ligand_indices)
+    reference = np.asarray(xyz[0], dtype=np.float64)
+
+    bubble_partners: list[int] = []
+    for atom_index in protein_indices.tolist():
+        deltas = reference[ligand_indices, :] - reference[int(atom_index), :]
+        if float(np.linalg.norm(deltas, axis=1).min()) <= float(bubble_cutoff):
+            bubble_partners.append(int(atom_index))
+
+    partner_indices = unique_indices(
+        np.asarray(bubble_partners, dtype=np.int64),
+        np.asarray(water_atom_indices, dtype=np.int64),
+    )
+    partner_indices = without_indices(partner_indices, ligand_indices)
+    if partner_indices.size == 0:
+        raise ValueError("bubble_distances did not find any nearby partner atoms.")
+
+    values = pairwise_distances(xyz, ligand_indices, partner_indices)
+    return FeatureComputation(
+        feature_type="bubble_distances",
+        values=values,
+        feature_names=_pair_feature_names(topology, ligand_indices, partner_indices, prefix="bubble"),
+        metadata={
+            "ligand_selection": ligand_selection,
+            "protein_selection": protein_selection,
+            "bubble_cutoff": float(bubble_cutoff),
+            "ligand_atom_count": int(ligand_indices.size),
+            "partner_atom_count": int(partner_indices.size),
+            "water_atom_count": int(np.asarray(water_atom_indices, dtype=np.int64).size),
+        },
+    )
+
+
+def _resolve_partner_indices(
+    *,
+    topology: Any,
+    ligand_indices: np.ndarray,
+    protein_selection: str,
+    water_atom_indices: tuple[int, ...],
+) -> np.ndarray:
+    """Resolve the partner atom indices for pairwise feature families."""
+
+    protein_indices = select_atom_indices(topology, protein_selection)
+    merged = unique_indices(protein_indices, np.asarray(water_atom_indices, dtype=np.int64))
+    partner_indices = without_indices(merged, ligand_indices)
+    if partner_indices.size == 0:
+        raise ValueError("No partner atoms were selected for the requested feature family.")
+    return partner_indices
+
+
+def _pair_feature_names(
+    topology: Any,
+    left_indices: np.ndarray,
+    right_indices: np.ndarray,
+    *,
+    prefix: str,
+) -> tuple[str, ...]:
+    """Build stable feature names for all left/right atom pairs."""
+
+    names: list[str] = []
+    for left_index in np.asarray(left_indices, dtype=np.int64).tolist():
+        left_atom = topology.atoms[int(left_index)]
+        for right_index in np.asarray(right_indices, dtype=np.int64).tolist():
+            right_atom = topology.atoms[int(right_index)]
+            names.append(f"{prefix}:{atom_label(left_atom)}__{atom_label(right_atom)}")
+    return tuple(names)
+
+
+__all__ = [
+    "all_ligand_protein_distances",
+    "bubble_distances",
+    "closest_residue_distances",
+]

--- a/src/mltsa/md/features/pca.py
+++ b/src/mltsa/md/features/pca.py
@@ -1,0 +1,56 @@
+"""PCA-based coordinate features for MD trajectories."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from .base import FeatureComputation, non_water_atom_indices, select_atom_indices
+
+
+def pca_xyz(
+    topology: Any,
+    xyz: np.ndarray,
+    *,
+    atom_selection: str | None = None,
+    n_components: int = 3,
+) -> FeatureComputation:
+    """Project selected Cartesian coordinates onto principal components."""
+
+    if n_components < 1:
+        raise ValueError("n_components must be at least 1.")
+
+    if atom_selection is None:
+        atom_indices = non_water_atom_indices(topology)
+        selection_label = "non_water"
+    else:
+        atom_indices = select_atom_indices(topology, atom_selection)
+        selection_label = atom_selection
+
+    matrix = np.asarray(xyz[:, atom_indices, :], dtype=np.float64).reshape(int(xyz.shape[0]), -1)
+    centered = matrix - matrix.mean(axis=0, keepdims=True)
+    _, singular_values, right_t = np.linalg.svd(centered, full_matrices=False)
+
+    component_count = min(int(n_components), int(right_t.shape[0]))
+    components = centered @ right_t[:component_count].T
+
+    total_variance = float(np.square(singular_values).sum())
+    if total_variance > 0.0:
+        explained_variance_ratio = (np.square(singular_values[:component_count]) / total_variance).tolist()
+    else:
+        explained_variance_ratio = [0.0] * component_count
+
+    return FeatureComputation(
+        feature_type="pca_xyz",
+        values=components,
+        feature_names=tuple(f"pc_{index:03d}" for index in range(component_count)),
+        metadata={
+            "atom_selection": selection_label,
+            "atom_indices": [int(index) for index in atom_indices.tolist()],
+            "explained_variance_ratio": [float(value) for value in explained_variance_ratio],
+        },
+    )
+
+
+__all__ = ["pca_xyz"]

--- a/src/mltsa/md/features/rules.py
+++ b/src/mltsa/md/features/rules.py
@@ -1,0 +1,261 @@
+"""Rule evaluation helpers for MD labeling workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+SelectionPair = tuple[str, str]
+
+WATER_RESIDUE_NAMES = {"HOH", "WAT", "SOL", "TIP3", "TIP3P", "TIP4", "TIP4P"}
+
+
+@dataclass(frozen=True, slots=True)
+class RuleEvaluation:
+    """Per-frame values produced by a labeling rule on a final trajectory window."""
+
+    rule: str
+    frame_values: np.ndarray
+    component_values: np.ndarray
+    component_labels: tuple[str, ...]
+    reference_atom_indices: tuple[int, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class WaterMetadata:
+    """Nearby-water summary for a trajectory window."""
+
+    atom_indices: tuple[int, ...]
+    residue_ids: tuple[int, ...]
+    residue_names: tuple[str, ...]
+    mean_distances: np.ndarray
+
+
+def evaluate_rule(
+    *,
+    topology: Any,
+    window_xyz: np.ndarray,
+    rule: str,
+    selection_pairs: tuple[SelectionPair, ...],
+) -> RuleEvaluation:
+    """Evaluate one supported labeling rule on a final trajectory window."""
+
+    normalized_rule = rule.strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized_rule == "sum_distances":
+        return _evaluate_sum_distances(topology=topology, window_xyz=window_xyz, selection_pairs=selection_pairs)
+    if normalized_rule == "com_distance":
+        return _evaluate_com_distance(topology=topology, window_xyz=window_xyz, selection_pairs=selection_pairs)
+    raise ValueError(f"Unsupported labeling rule {rule!r}.")
+
+
+def gather_nearby_waters(
+    *,
+    topology: Any,
+    window_xyz: np.ndarray,
+    reference_atom_indices: tuple[int, ...],
+    n_waters: int = 50,
+) -> WaterMetadata:
+    """Collect mean distances for the nearest water residues around a reference selection."""
+
+    if n_waters < 1:
+        raise ValueError("n_waters must be at least 1.")
+
+    reference_indices = np.asarray(reference_atom_indices, dtype=np.int64)
+    if reference_indices.size == 0:
+        return WaterMetadata(atom_indices=(), residue_ids=(), residue_names=(), mean_distances=np.empty(0, dtype=np.float64))
+
+    reference_com = _compute_center_of_mass(window_xyz, topology, reference_indices)
+    candidates: list[tuple[float, int, int, str]] = []
+
+    for residue, residue_atom_indices in _water_residue_groups(topology):
+        water_indices = np.asarray(_preferred_water_atom_indices(residue_atom_indices, topology), dtype=np.int64)
+        water_com = _compute_center_of_mass(window_xyz, topology, water_indices)
+        mean_distance = float(np.linalg.norm(reference_com - water_com, axis=1).mean())
+        candidates.append((mean_distance, int(water_indices[0]), _residue_id(residue), _residue_name(residue)))
+
+    candidates.sort(key=lambda item: item[0])
+    selected = candidates[:n_waters]
+
+    return WaterMetadata(
+        atom_indices=tuple(item[1] for item in selected),
+        residue_ids=tuple(item[2] for item in selected),
+        residue_names=tuple(item[3] for item in selected),
+        mean_distances=np.asarray([item[0] for item in selected], dtype=np.float64),
+    )
+
+
+def _evaluate_sum_distances(
+    *,
+    topology: Any,
+    window_xyz: np.ndarray,
+    selection_pairs: tuple[SelectionPair, ...],
+) -> RuleEvaluation:
+    """Evaluate the frame-wise sum of atom-pair distances."""
+
+    if not selection_pairs:
+        raise ValueError("sum_distances requires at least one selection pair.")
+
+    resolved_pairs: list[tuple[int, int]] = []
+    component_labels: list[str] = []
+    reference_indices: set[int] = set()
+
+    for selection_a, selection_b in selection_pairs:
+        indices_a = _select_indices(topology, selection_a)
+        indices_b = _select_indices(topology, selection_b)
+        if indices_a.size != 1 or indices_b.size != 1:
+            raise ValueError(
+                "sum_distances expects each selection to resolve to exactly one atom. "
+                "Use com_distance when selections contain multiple atoms."
+            )
+        atom_a = int(indices_a[0])
+        atom_b = int(indices_b[0])
+        resolved_pairs.append((atom_a, atom_b))
+        component_labels.append(f"{selection_a} -> {selection_b}")
+        reference_indices.update((atom_a, atom_b))
+
+    component_values = _pair_distances(window_xyz, resolved_pairs)
+    frame_values = component_values.sum(axis=1)
+    return RuleEvaluation(
+        rule="sum_distances",
+        frame_values=frame_values,
+        component_values=component_values,
+        component_labels=tuple(component_labels),
+        reference_atom_indices=tuple(sorted(reference_indices)),
+    )
+
+
+def _evaluate_com_distance(
+    *,
+    topology: Any,
+    window_xyz: np.ndarray,
+    selection_pairs: tuple[SelectionPair, ...],
+) -> RuleEvaluation:
+    """Evaluate the frame-wise center-of-mass distance between two selections."""
+
+    if len(selection_pairs) != 1:
+        raise ValueError("com_distance requires exactly one selection pair.")
+
+    selection_a, selection_b = selection_pairs[0]
+    indices_a = _select_indices(topology, selection_a)
+    indices_b = _select_indices(topology, selection_b)
+
+    com_a = _compute_center_of_mass(window_xyz, topology, indices_a)
+    com_b = _compute_center_of_mass(window_xyz, topology, indices_b)
+    frame_values = np.linalg.norm(com_a - com_b, axis=1)
+    component_values = frame_values[:, None]
+    return RuleEvaluation(
+        rule="com_distance",
+        frame_values=frame_values,
+        component_values=component_values,
+        component_labels=(f"COM({selection_a}) -> COM({selection_b})",),
+        reference_atom_indices=tuple(sorted({*(int(index) for index in indices_a), *(int(index) for index in indices_b)})),
+    )
+
+
+def _select_indices(topology: Any, selection: str) -> np.ndarray:
+    """Resolve an mdtraj selection string into atom indices."""
+
+    indices = np.asarray(topology.select(selection), dtype=np.int64)
+    if indices.ndim != 1 or indices.size == 0:
+        raise ValueError(f"Selection {selection!r} did not resolve to any atoms.")
+    return indices
+
+
+def _pair_distances(window_xyz: np.ndarray, pairs: list[tuple[int, int]]) -> np.ndarray:
+    """Compute Euclidean distances for atom pairs across all frames in a window."""
+
+    component_values = np.empty((window_xyz.shape[0], len(pairs)), dtype=np.float64)
+    for column, (atom_a, atom_b) in enumerate(pairs):
+        delta = window_xyz[:, atom_a, :] - window_xyz[:, atom_b, :]
+        component_values[:, column] = np.linalg.norm(delta, axis=1)
+    return component_values
+
+
+def _compute_center_of_mass(window_xyz: np.ndarray, topology: Any, atom_indices: np.ndarray) -> np.ndarray:
+    """Compute a center-of-mass series across frames for a selection."""
+
+    masses = np.asarray([_atom_mass(_atom_by_index(topology, int(index))) for index in atom_indices], dtype=np.float64)
+    total_mass = float(masses.sum())
+    if total_mass <= 0.0:
+        masses = np.ones(atom_indices.shape[0], dtype=np.float64)
+        total_mass = float(masses.sum())
+
+    coords = window_xyz[:, atom_indices, :]
+    return (coords * masses[None, :, None]).sum(axis=1) / total_mass
+
+
+def _water_residue_groups(topology: Any) -> list[tuple[Any, list[int]]]:
+    """Group water atoms by residue."""
+
+    groups: dict[int, tuple[Any, list[int]]] = {}
+    for atom in topology.atoms:
+        residue = atom.residue
+        if not _is_water_residue(residue):
+            continue
+        key = id(residue)
+        if key not in groups:
+            groups[key] = (residue, [])
+        groups[key][1].append(int(atom.index))
+    return list(groups.values())
+
+
+def _preferred_water_atom_indices(atom_indices: list[int], topology: Any) -> list[int]:
+    """Prefer water oxygen atoms when available, otherwise use the full residue."""
+
+    oxygen_indices = [index for index in atom_indices if _atom_name(_atom_by_index(topology, index)).upper().startswith("O")]
+    return oxygen_indices or atom_indices
+
+
+def _is_water_residue(residue: Any) -> bool:
+    """Return ``True`` when a residue looks like water."""
+
+    if bool(getattr(residue, "is_water", False)):
+        return True
+    return _residue_name(residue).upper() in WATER_RESIDUE_NAMES
+
+
+def _atom_by_index(topology: Any, atom_index: int) -> Any:
+    """Fetch an atom object by index from a topology."""
+
+    return topology.atoms[atom_index]
+
+
+def _atom_name(atom: Any) -> str:
+    """Return a normalized atom name."""
+
+    return str(getattr(atom, "name", getattr(atom, "element", "X")))
+
+
+def _atom_mass(atom: Any) -> float:
+    """Return an atomic mass, defaulting to 1.0 when unavailable."""
+
+    element = getattr(atom, "element", None)
+    if element is not None:
+        mass = getattr(element, "mass", None)
+        if mass is not None:
+            return float(mass)
+    mass = getattr(atom, "mass", None)
+    if mass is not None:
+        return float(mass)
+    return 1.0
+
+
+def _residue_name(residue: Any) -> str:
+    """Return a residue name."""
+
+    return str(getattr(residue, "name", "UNK"))
+
+
+def _residue_id(residue: Any) -> int:
+    """Return a stable residue identifier when possible."""
+
+    if hasattr(residue, "resSeq"):
+        return int(residue.resSeq)
+    if hasattr(residue, "index"):
+        return int(residue.index)
+    return 0
+
+
+__all__ = ["RuleEvaluation", "SelectionPair", "WaterMetadata", "evaluate_rule", "gather_nearby_waters"]

--- a/src/mltsa/md/features/waters.py
+++ b/src/mltsa/md/features/waters.py
@@ -1,0 +1,26 @@
+"""Helpers for reusing stored nearby-water metadata during featurization."""
+
+from __future__ import annotations
+
+from typing import Final
+
+import h5py
+
+WATERS_GROUP_NAME: Final[str] = "nearby_waters"
+
+
+def read_stored_water_atom_indices(label_entry: h5py.Group) -> tuple[int, ...]:
+    """Read stored nearby-water atom indices from a label entry when available."""
+
+    waters = label_entry.get(WATERS_GROUP_NAME, default=None)
+    if not isinstance(waters, h5py.Group):
+        return ()
+
+    atom_indices = waters.get("atom_indices", default=None)
+    if not isinstance(atom_indices, h5py.Dataset):
+        return ()
+
+    return tuple(int(value) for value in atom_indices[...].tolist())
+
+
+__all__ = ["WATERS_GROUP_NAME", "read_stored_water_atom_indices"]

--- a/src/mltsa/md/featurize.py
+++ b/src/mltsa/md/featurize.py
@@ -1,0 +1,570 @@
+"""MD featurization helpers built on the appendable mltsa HDF5 schema."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import h5py
+import numpy as np
+
+from mltsa.io.h5 import ensure_group, open_h5, read_utf8_array, replace_dataset, write_utf8_array
+from mltsa.io.schema import ensure_md_layout, feature_set_path, replica_path, results_experiment_path
+from mltsa.synthetic.base import JSONValue, canonical_json
+
+from .features.base import (
+    FEATURE_SET_SCHEMA,
+    FEATURE_SET_SCHEMA_VERSION,
+    FeatureComputation,
+    MDFeatureDataset,
+    normalize_feature_type,
+    normalize_path,
+    state_to_int,
+    validate_replica_id,
+)
+from .features.contacts import contact_map
+from .features.distances import all_ligand_protein_distances, bubble_distances, closest_residue_distances
+from .features.pca import pca_xyz
+from .features.waters import read_stored_water_atom_indices
+
+FEATURE_REPLICAS_GROUP = "replicas"
+
+
+@dataclass(frozen=True, slots=True)
+class LabelSourceEntry:
+    """Replica metadata read from a stored MD labeling result."""
+
+    entry_key: str
+    replica_id: str
+    trajectory_path: str
+    normalized_trajectory_path: str
+    topology_path: str
+    state_label: str
+    y: int
+    water_atom_indices: tuple[int, ...]
+
+
+def featurize_dataset(
+    *,
+    h5_path: str | Path,
+    feature_set: str,
+    feature_type: str,
+    label_experiment_id: str,
+    replica_ids: Sequence[str] | None = None,
+    append: bool = False,
+    overwrite: bool = False,
+    use_waters: bool = False,
+    ligand_selection: str = "resname LIG",
+    protein_selection: str = "protein",
+    bubble_cutoff: float = 0.6,
+    contact_threshold: float = 0.45,
+    pca_components: int = 3,
+    pca_selection: str | None = None,
+) -> MDFeatureDataset:
+    """Compute one named MD feature set from trajectories already labeled in the HDF5 file."""
+
+    normalized_feature_type = normalize_feature_type(feature_type)
+    feature_set_id = validate_replica_id(feature_set)
+    requested_replica_ids = None if replica_ids is None else tuple(validate_replica_id(value) for value in replica_ids)
+    file_path = Path(h5_path)
+    config = _feature_config(
+        feature_type=normalized_feature_type,
+        ligand_selection=ligand_selection,
+        protein_selection=protein_selection,
+        bubble_cutoff=bubble_cutoff,
+        contact_threshold=contact_threshold,
+        pca_components=pca_components,
+        pca_selection=pca_selection,
+        use_waters=use_waters,
+    )
+
+    processed: list[str] = []
+    skipped: list[str] = []
+    overwritten: list[str] = []
+
+    with open_h5(file_path, "a") as handle:
+        ensure_md_layout(handle)
+        label_entries = _load_label_entries(
+            handle,
+            label_experiment_id=label_experiment_id,
+            replica_ids=requested_replica_ids,
+            use_waters=use_waters,
+        )
+        feature_group = _prepare_feature_group(
+            handle,
+            feature_set=feature_set_id,
+            feature_type=normalized_feature_type,
+            label_experiment_id=label_experiment_id,
+            config=config,
+            append=append,
+            overwrite=overwrite,
+        )
+        replicas_group = ensure_group(feature_group, FEATURE_REPLICAS_GROUP)
+        existing = _scan_existing_replicas(replicas_group)
+        expected_feature_names = tuple(read_utf8_array(feature_group, "feature_names")) if "feature_names" in feature_group else None
+
+        md = _import_mdtraj()
+        for entry in label_entries:
+            stored = existing.get(entry.replica_id)
+            if stored is not None:
+                if stored.normalized_trajectory_path != entry.normalized_trajectory_path:
+                    raise ValueError(
+                        f"Feature set {feature_set_id!r} already contains replica {entry.replica_id!r} "
+                        "for a different trajectory path. Rebuild the feature set with overwrite=True "
+                        "and append=False if you want to replace it."
+                    )
+                if append and not overwrite:
+                    skipped.append(entry.replica_id)
+                    continue
+                del replicas_group[entry.replica_id]
+                overwritten.append(entry.replica_id)
+
+            trajectory = _load_trajectory(md, Path(entry.trajectory_path), Path(entry.topology_path))
+            topology = getattr(trajectory, "topology", getattr(trajectory, "top", None))
+            if topology is None:
+                raise TypeError("Loaded trajectory does not expose a topology object.")
+            xyz = np.asarray(trajectory.xyz, dtype=np.float64)
+            if xyz.ndim != 3 or xyz.shape[0] < 1:
+                raise ValueError(f"Trajectory {entry.trajectory_path} does not contain usable coordinates.")
+
+            computation = _compute_features(
+                topology=topology,
+                xyz=xyz,
+                feature_type=normalized_feature_type,
+                ligand_selection=ligand_selection,
+                protein_selection=protein_selection,
+                bubble_cutoff=bubble_cutoff,
+                contact_threshold=contact_threshold,
+                pca_components=pca_components,
+                pca_selection=pca_selection,
+                water_atom_indices=entry.water_atom_indices if use_waters else (),
+            )
+
+            if expected_feature_names is None:
+                write_utf8_array(feature_group, "feature_names", computation.feature_names, overwrite=True)
+                expected_feature_names = computation.feature_names
+            elif expected_feature_names != computation.feature_names:
+                raise ValueError(
+                    f"Replica {entry.replica_id!r} produced feature names that do not match the "
+                    f"existing feature set {feature_set_id!r}."
+                )
+
+            _write_replica_metadata(handle, entry, label_experiment_id=label_experiment_id)
+            _write_replica_features(replicas_group, entry, computation)
+            processed.append(entry.replica_id)
+
+        feature_group.attrs["n_replicas"] = int(len(replicas_group))
+        feature_group.attrs["feature_dim"] = int(len(expected_feature_names or ()))
+
+        return _load_dataset_from_handle(
+            handle,
+            feature_set=feature_set_id,
+            processed_replica_ids=tuple(processed),
+            skipped_replica_ids=tuple(skipped),
+            overwritten_replica_ids=tuple(overwritten),
+        )
+
+
+def load_dataset(path: str | Path, feature_set: str) -> MDFeatureDataset:
+    """Load one selected MD feature set from an HDF5 file."""
+
+    with open_h5(path, "r") as handle:
+        return _load_dataset_from_handle(handle, feature_set=validate_replica_id(feature_set))
+
+
+def _prepare_feature_group(
+    handle: h5py.File,
+    *,
+    feature_set: str,
+    feature_type: str,
+    label_experiment_id: str,
+    config: dict[str, JSONValue],
+    append: bool,
+    overwrite: bool,
+) -> h5py.Group:
+    """Create or validate the on-disk feature-set group."""
+
+    feature_path = feature_set_path(feature_set)
+    if feature_path in handle and not append:
+        if not overwrite:
+            raise ValueError(
+                f"Feature set already exists at {feature_path!r}. Use append=True to add missing replicas "
+                "or overwrite=True to rebuild the feature set."
+            )
+        del handle[feature_path]
+
+    feature_group = ensure_group(
+        handle,
+        feature_path,
+        attrs={
+            "schema": FEATURE_SET_SCHEMA,
+            "schema_version": FEATURE_SET_SCHEMA_VERSION,
+            "feature_type": feature_type,
+            "label_experiment_id": label_experiment_id,
+            "feature_config_json": canonical_json(config),
+            "kind": "md_feature_set",
+            "use_waters": bool(config["use_waters"]),
+        },
+    )
+
+    replicas_group = ensure_group(feature_group, FEATURE_REPLICAS_GROUP)
+    if len(replicas_group) > 0:
+        _validate_feature_group_config(
+            feature_group,
+            feature_type=feature_type,
+            label_experiment_id=label_experiment_id,
+            config=config,
+            append=append,
+            overwrite=overwrite,
+        )
+    return feature_group
+
+
+def _validate_feature_group_config(
+    feature_group: h5py.Group,
+    *,
+    feature_type: str,
+    label_experiment_id: str,
+    config: dict[str, JSONValue],
+    append: bool,
+    overwrite: bool,
+) -> None:
+    """Prevent accidental mixing of incompatible feature-set configurations."""
+
+    expected = {
+        "feature_type": feature_type,
+        "label_experiment_id": label_experiment_id,
+        "feature_config_json": canonical_json(config),
+        "use_waters": bool(config["use_waters"]),
+    }
+    current = {name: _normalize_attr(feature_group.attrs.get(name)) for name in expected}
+    if current == expected:
+        return
+
+    if append and not overwrite:
+        raise ValueError(
+            "Existing feature-set configuration does not match the requested featurization setup. "
+            "Use overwrite=True with append=False to rebuild the feature set."
+        )
+    if append and overwrite:
+        raise ValueError(
+            "Appending with overwrite=True can replace matching replicas, but it cannot safely change the "
+            "feature-set configuration while keeping other stored replicas. Re-run with append=False and overwrite=True."
+        )
+
+
+def _load_label_entries(
+    handle: h5py.File,
+    *,
+    label_experiment_id: str,
+    replica_ids: tuple[str, ...] | None,
+    use_waters: bool,
+) -> list[LabelSourceEntry]:
+    """Read replica metadata from a stored trajectory-labeling result."""
+
+    entries_path = f"{results_experiment_path(label_experiment_id)}/trajectory_labels/entries"
+    entries_group = handle.get(entries_path, default=None)
+    if not isinstance(entries_group, h5py.Group):
+        raise ValueError(
+            f"Could not find stored MD labels at {entries_path!r}. Run label_trajectories(...) first."
+        )
+
+    requested = None if replica_ids is None else set(replica_ids)
+    entries: list[LabelSourceEntry] = []
+
+    for entry_key, child in entries_group.items():
+        if not isinstance(child, h5py.Group):
+            continue
+        replica_id = validate_replica_id(str(child.attrs["replica_id"]))
+        if requested is not None and replica_id not in requested:
+            continue
+
+        state_label = str(child.attrs["state_label"]).upper()
+        trajectory_path = str(child.attrs["trajectory_path"])
+        entries.append(
+            LabelSourceEntry(
+                entry_key=str(entry_key),
+                replica_id=replica_id,
+                trajectory_path=trajectory_path,
+                normalized_trajectory_path=str(child.attrs.get("normalized_trajectory_path", normalize_path(trajectory_path))),
+                topology_path=str(child.attrs["topology_path"]),
+                state_label=state_label,
+                y=state_to_int(state_label),
+                water_atom_indices=read_stored_water_atom_indices(child) if use_waters else (),
+            )
+        )
+
+    if requested is not None:
+        found = {entry.replica_id for entry in entries}
+        missing = sorted(requested.difference(found))
+        if missing:
+            raise ValueError(f"Requested replica ids are missing from the label store: {missing}")
+
+    if not entries:
+        raise ValueError("No labeled replicas matched the requested featurization inputs.")
+
+    entries.sort(key=lambda entry: entry.replica_id)
+    return entries
+
+
+def _scan_existing_replicas(replicas_group: h5py.Group) -> dict[str, LabelSourceEntry]:
+    """Collect existing featurized replicas using only child groups and attributes."""
+
+    existing: dict[str, LabelSourceEntry] = {}
+    for replica_id, child in replicas_group.items():
+        if not isinstance(child, h5py.Group):
+            continue
+        normalized_trajectory_path = str(child.attrs.get("normalized_trajectory_path", ""))
+        state_label = str(child.attrs.get("state_label", "IN")).upper()
+        existing[str(replica_id)] = LabelSourceEntry(
+            entry_key=str(replica_id),
+            replica_id=str(replica_id),
+            trajectory_path=str(child.attrs.get("trajectory_path", "")),
+            normalized_trajectory_path=normalized_trajectory_path,
+            topology_path=str(child.attrs.get("topology_path", "")),
+            state_label=state_label,
+            y=state_to_int(state_label),
+            water_atom_indices=(),
+        )
+    return existing
+
+
+def _write_replica_metadata(handle: h5py.File, entry: LabelSourceEntry, *, label_experiment_id: str) -> None:
+    """Persist lightweight per-replica metadata under the canonical MD schema root."""
+
+    replica_group = ensure_group(
+        handle,
+        replica_path(entry.replica_id),
+        attrs={
+            "kind": "md_replica",
+            "trajectory_path": entry.trajectory_path,
+            "normalized_trajectory_path": entry.normalized_trajectory_path,
+            "topology_path": entry.topology_path,
+        },
+    )
+    ensure_group(
+        replica_group,
+        f"labels/{label_experiment_id}",
+        attrs={
+            "kind": "md_replica_label",
+            "state_label": entry.state_label,
+            "label_code": int(entry.y),
+            "label_entry_path": f"{results_experiment_path(label_experiment_id)}/trajectory_labels/entries/{entry.entry_key}",
+        },
+    )
+
+
+def _write_replica_features(replicas_group: h5py.Group, entry: LabelSourceEntry, computation: FeatureComputation) -> None:
+    """Write one featurized replica to HDF5."""
+
+    replica_group = ensure_group(
+        replicas_group,
+        entry.replica_id,
+        attrs={
+            "kind": "md_featurized_replica",
+            "replica_id": entry.replica_id,
+            "trajectory_path": entry.trajectory_path,
+            "normalized_trajectory_path": entry.normalized_trajectory_path,
+            "topology_path": entry.topology_path,
+            "state_label": entry.state_label,
+            "label_code": int(entry.y),
+            "metadata_json": canonical_json(computation.metadata),
+            "n_frames": int(computation.values.shape[0]),
+            "n_features": int(computation.values.shape[1]),
+        },
+    )
+    replace_dataset(replica_group, "X", computation.values)
+
+
+def _compute_features(
+    *,
+    topology: Any,
+    xyz: np.ndarray,
+    feature_type: str,
+    ligand_selection: str,
+    protein_selection: str,
+    bubble_cutoff: float,
+    contact_threshold: float,
+    pca_components: int,
+    pca_selection: str | None,
+    water_atom_indices: tuple[int, ...],
+) -> FeatureComputation:
+    """Dispatch one supported feature family."""
+
+    if feature_type == "closest_residue_distances":
+        return closest_residue_distances(
+            topology,
+            xyz,
+            ligand_selection=ligand_selection,
+            protein_selection=protein_selection,
+            water_atom_indices=water_atom_indices,
+        )
+    if feature_type == "all_ligand_protein_distances":
+        return all_ligand_protein_distances(
+            topology,
+            xyz,
+            ligand_selection=ligand_selection,
+            protein_selection=protein_selection,
+            water_atom_indices=water_atom_indices,
+        )
+    if feature_type == "bubble_distances":
+        return bubble_distances(
+            topology,
+            xyz,
+            ligand_selection=ligand_selection,
+            protein_selection=protein_selection,
+            bubble_cutoff=bubble_cutoff,
+            water_atom_indices=water_atom_indices,
+        )
+    if feature_type == "contact_map":
+        return contact_map(
+            topology,
+            xyz,
+            ligand_selection=ligand_selection,
+            protein_selection=protein_selection,
+            contact_threshold=contact_threshold,
+            water_atom_indices=water_atom_indices,
+        )
+    if feature_type == "pca_xyz":
+        return pca_xyz(
+            topology,
+            xyz,
+            atom_selection=pca_selection,
+            n_components=pca_components,
+        )
+    raise ValueError(f"Unsupported MD feature type {feature_type!r}.")
+
+
+def _load_dataset_from_handle(
+    handle: h5py.File,
+    *,
+    feature_set: str,
+    processed_replica_ids: tuple[str, ...] = (),
+    skipped_replica_ids: tuple[str, ...] = (),
+    overwritten_replica_ids: tuple[str, ...] = (),
+) -> MDFeatureDataset:
+    """Load one feature set from an already-open HDF5 handle."""
+
+    feature_group = handle.get(feature_set_path(feature_set), default=None)
+    if not isinstance(feature_group, h5py.Group):
+        raise ValueError(f"Could not find feature set {feature_set!r} in the HDF5 file.")
+
+    replicas_group = feature_group.get(FEATURE_REPLICAS_GROUP, default=None)
+    if not isinstance(replicas_group, h5py.Group):
+        raise ValueError(f"Feature set {feature_set!r} does not contain any replica groups.")
+
+    feature_names = tuple(read_utf8_array(feature_group, "feature_names"))
+    arrays: list[np.ndarray] = []
+    y_values: list[int] = []
+    state_labels: list[str] = []
+    replica_ids: list[str] = []
+    trajectory_paths: list[str] = []
+    topology_paths: list[str] = []
+
+    expected_shape: tuple[int, int] | None = None
+    for replica_id in sorted(replicas_group.keys()):
+        child = replicas_group[replica_id]
+        if not isinstance(child, h5py.Group):
+            continue
+        values = np.asarray(child["X"][...], dtype=np.float64)
+        if values.ndim != 2:
+            raise ValueError(f"Replica {replica_id!r} does not contain a 2D feature matrix.")
+        if values.shape[1] != len(feature_names):
+            raise ValueError(f"Replica {replica_id!r} has a feature dimension that does not match feature_names.")
+        if expected_shape is None:
+            expected_shape = (int(values.shape[0]), int(values.shape[1]))
+        elif expected_shape != (int(values.shape[0]), int(values.shape[1])):
+            raise ValueError(
+                "Stored replicas do not share a common frame/feature shape, so they cannot be loaded "
+                "as one stacked dataset."
+            )
+
+        arrays.append(values)
+        replica_ids.append(str(replica_id))
+        state_labels.append(str(child.attrs["state_label"]))
+        y_values.append(int(child.attrs["label_code"]))
+        trajectory_paths.append(str(child.attrs["trajectory_path"]))
+        topology_paths.append(str(child.attrs["topology_path"]))
+
+    if not arrays:
+        raise ValueError(f"Feature set {feature_set!r} does not contain any stored replica matrices.")
+
+    metadata = json.loads(str(feature_group.attrs["feature_config_json"]))
+    metadata["label_experiment_id"] = str(feature_group.attrs["label_experiment_id"])
+
+    return MDFeatureDataset(
+        feature_set=feature_set,
+        feature_type=str(feature_group.attrs["feature_type"]),
+        X=np.stack(arrays, axis=0),
+        y=np.asarray(y_values, dtype=np.int64),
+        state_labels=tuple(state_labels),
+        feature_names=feature_names,
+        replica_ids=tuple(replica_ids),
+        trajectory_paths=tuple(trajectory_paths),
+        topology_paths=tuple(topology_paths),
+        metadata=metadata,
+        processed_replica_ids=processed_replica_ids,
+        skipped_replica_ids=skipped_replica_ids,
+        overwritten_replica_ids=overwritten_replica_ids,
+    )
+
+
+def _feature_config(
+    *,
+    feature_type: str,
+    ligand_selection: str,
+    protein_selection: str,
+    bubble_cutoff: float,
+    contact_threshold: float,
+    pca_components: int,
+    pca_selection: str | None,
+    use_waters: bool,
+) -> dict[str, JSONValue]:
+    """Build canonical feature-set configuration metadata."""
+
+    config: dict[str, JSONValue] = {
+        "feature_type": feature_type,
+        "ligand_selection": ligand_selection,
+        "protein_selection": protein_selection,
+        "use_waters": bool(use_waters),
+    }
+    if feature_type == "bubble_distances":
+        config["bubble_cutoff"] = float(bubble_cutoff)
+    if feature_type == "contact_map":
+        config["contact_threshold"] = float(contact_threshold)
+    if feature_type == "pca_xyz":
+        config["pca_components"] = int(pca_components)
+        config["pca_selection"] = pca_selection if pca_selection is not None else "non_water"
+    return config
+
+
+def _import_mdtraj() -> Any:
+    """Import mdtraj lazily so package import stays lightweight."""
+
+    try:
+        import mdtraj as md
+    except ImportError as exc:  # pragma: no cover - exercised only in user environments.
+        raise ImportError(
+            "featurize_dataset requires mdtraj at runtime. Install the optional dependency set "
+            "with `pip install mltsa[md]` or provide mdtraj in the active environment."
+        ) from exc
+    return md
+
+
+def _load_trajectory(md: Any, trajectory_path: Path, topology_path: Path) -> Any:
+    """Load one trajectory through mdtraj using a shared topology."""
+
+    return md.load(str(trajectory_path), top=str(topology_path))
+
+
+def _normalize_attr(value: object) -> JSONValue:
+    """Convert HDF5 attribute values to plain JSON-compatible Python values."""
+
+    if isinstance(value, np.generic):
+        return value.item()
+    return value  # type: ignore[return-value]
+
+
+__all__ = ["MDFeatureDataset", "featurize_dataset", "load_dataset"]

--- a/src/mltsa/md/label.py
+++ b/src/mltsa/md/label.py
@@ -1,0 +1,686 @@
+"""Trajectory labeling helpers for molecular dynamics workflows."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Sequence
+
+import h5py
+import numpy as np
+
+from mltsa.io.h5 import ensure_group, open_h5, replace_dataset, write_utf8_array
+from mltsa.io.schema import ensure_results_layout, results_experiment_path
+from mltsa.md.features.rules import SelectionPair, WaterMetadata, evaluate_rule, gather_nearby_waters
+from mltsa.synthetic.base import JSONValue, canonical_json
+
+LABEL_SCHEMA_VERSION = 1
+LABELS_GROUP_NAME = "trajectory_labels"
+ENTRIES_GROUP_NAME = "entries"
+STATE_ORDER = ("IN", "OUT", "TS")
+
+
+@dataclass(frozen=True, slots=True)
+class SnapshotModel:
+    """Single-frame snapshot used for optional PDB export."""
+
+    label: str
+    xyz: np.ndarray
+    topology: Any
+    trajectory_path: str
+    replica_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectoryLabelEntry:
+    """Labeled result for one trajectory."""
+
+    entry_key: str
+    trajectory_path: str
+    normalized_trajectory_path: str
+    topology_path: str
+    replica_id: str
+    label: str
+    mean_value: float
+    frame_values: np.ndarray
+    component_values: np.ndarray
+    component_labels: tuple[str, ...]
+    rule: str
+    n_frames_total: int
+    final_window_start: int
+    nearby_waters: WaterMetadata | None
+
+
+@dataclass(frozen=True, slots=True)
+class LabelingResult:
+    """Summary returned by :func:`label_trajectories`."""
+
+    experiment_path: str
+    h5_path: Path
+    processed: tuple[TrajectoryLabelEntry, ...]
+    skipped_entry_keys: tuple[str, ...]
+    overwritten_entry_keys: tuple[str, ...]
+    state_counts: dict[str, int]
+    summary_path: Path
+    pie_chart_path: Path
+    snapshot_paths: dict[str, Path]
+
+
+def label_trajectories(
+    *,
+    trajectory_paths: Sequence[str | Path],
+    topology: str | Path | Sequence[str | Path],
+    h5_path: str | Path,
+    experiment_id: str,
+    rule: str,
+    selection_pairs: Sequence[SelectionPair],
+    lower_threshold: float,
+    upper_threshold: float,
+    window_size: int,
+    replica_ids: Sequence[str] | None = None,
+    append: bool = False,
+    overwrite: bool = False,
+    store_waters: bool = True,
+    n_waters: int = 50,
+    export_snapshots: bool = False,
+    snapshot_dir: str | Path | None = None,
+    center_snapshots: bool = False,
+    align_protein: bool = False,
+    report_dir: str | Path | None = None,
+) -> LabelingResult:
+    """Label trajectories from the mean rule value on the final ``window_size`` frames.
+
+    ``sum_distances`` expects one or more atom-pair selections. ``com_distance``
+    requires exactly one selection pair and uses the center of mass of each
+    selection. Thresholds are interpreted in the same units as the underlying
+    mdtraj coordinates, which are typically nanometers.
+    """
+
+    normalized_rule = _normalize_rule(rule)
+    if window_size < 1:
+        raise ValueError("window_size must be at least 1.")
+    if upper_threshold < lower_threshold:
+        raise ValueError("upper_threshold must be greater than or equal to lower_threshold.")
+
+    trajectory_list = [Path(path) for path in trajectory_paths]
+    if not trajectory_list:
+        raise ValueError("trajectory_paths must not be empty.")
+
+    topology_list = _normalize_topology_paths(topology, len(trajectory_list))
+    replica_list = _normalize_replica_ids(replica_ids, trajectory_list)
+    selection_tuple = tuple((str(left), str(right)) for left, right in selection_pairs)
+    if not selection_tuple:
+        raise ValueError("selection_pairs must not be empty.")
+
+    md = _import_mdtraj()
+    result_file = Path(h5_path)
+    report_root = Path(report_dir) if report_dir is not None else result_file.parent
+    snapshot_root = Path(snapshot_dir) if snapshot_dir is not None else report_root / "snapshots" / _safe_file_stem(experiment_id)
+
+    store_config = _store_config(
+        rule=normalized_rule,
+        lower_threshold=lower_threshold,
+        upper_threshold=upper_threshold,
+        window_size=window_size,
+        selection_pairs=selection_tuple,
+        store_waters=store_waters,
+        n_waters=n_waters,
+    )
+
+    processed: list[TrajectoryLabelEntry] = []
+    skipped_entry_keys: list[str] = []
+    overwritten_entry_keys: list[str] = []
+    snapshots: list[SnapshotModel] = []
+
+    experiment_path = f"{results_experiment_path(experiment_id)}/{LABELS_GROUP_NAME}"
+    with open_h5(result_file, "a") as handle:
+        ensure_results_layout(handle)
+        experiment_group = ensure_group(handle, results_experiment_path(experiment_id), attrs={"kind": "md_labeling"})
+
+        if LABELS_GROUP_NAME in experiment_group and not append:
+            if not overwrite:
+                raise ValueError(
+                    f"Label store already exists at {experiment_path!r}. Use append=True to add entries "
+                    "or overwrite=True to replace the store."
+                )
+            del experiment_group[LABELS_GROUP_NAME]
+
+        label_group = ensure_group(
+            experiment_group,
+            LABELS_GROUP_NAME,
+            attrs={
+                "schema": "mltsa.md.labels",
+                "schema_version": LABEL_SCHEMA_VERSION,
+                **store_config,
+            },
+        )
+        entries_group = ensure_group(label_group, ENTRIES_GROUP_NAME)
+        write_utf8_array(
+            label_group,
+            "selection_pairs",
+            [json.dumps({"left": left, "right": right}, sort_keys=True) for left, right in selection_tuple],
+            overwrite=True,
+        )
+
+        if len(entries_group) > 0:
+            _validate_store_config(label_group, store_config, append=append, overwrite=overwrite)
+
+        for trajectory_path, topology_path, replica_id in zip(trajectory_list, topology_list, replica_list):
+            normalized_trajectory_path = _normalize_path(trajectory_path)
+            entry_key = _entry_key(replica_id, normalized_trajectory_path)
+            existing = entries_group.get(entry_key)
+
+            if existing is not None and append and not overwrite:
+                skipped_entry_keys.append(entry_key)
+                continue
+            if existing is not None and overwrite:
+                del entries_group[entry_key]
+                overwritten_entry_keys.append(entry_key)
+
+            trajectory = _load_trajectory(md, trajectory_path, topology_path)
+            topology_obj = getattr(trajectory, "topology", getattr(trajectory, "top", None))
+            if topology_obj is None:
+                raise TypeError("Loaded trajectory does not expose a topology object.")
+
+            n_frames_total = int(trajectory.xyz.shape[0])
+            if n_frames_total < 1:
+                raise ValueError(f"Trajectory {trajectory_path} does not contain any frames.")
+            final_window_start = max(0, n_frames_total - window_size)
+            window_xyz = np.asarray(trajectory.xyz[final_window_start:], dtype=np.float64)
+            evaluation = evaluate_rule(
+                topology=topology_obj,
+                window_xyz=window_xyz,
+                rule=normalized_rule,
+                selection_pairs=selection_tuple,
+            )
+            mean_value = float(evaluation.frame_values.mean())
+            label = _classify_state(mean_value, lower_threshold=lower_threshold, upper_threshold=upper_threshold)
+
+            nearby_waters = (
+                gather_nearby_waters(
+                    topology=topology_obj,
+                    window_xyz=window_xyz,
+                    reference_atom_indices=evaluation.reference_atom_indices,
+                    n_waters=n_waters,
+                )
+                if store_waters
+                else None
+            )
+
+            entry = TrajectoryLabelEntry(
+                entry_key=entry_key,
+                trajectory_path=str(trajectory_path),
+                normalized_trajectory_path=normalized_trajectory_path,
+                topology_path=str(topology_path),
+                replica_id=replica_id,
+                label=label,
+                mean_value=mean_value,
+                frame_values=np.asarray(evaluation.frame_values, dtype=np.float64),
+                component_values=np.asarray(evaluation.component_values, dtype=np.float64),
+                component_labels=tuple(evaluation.component_labels),
+                rule=normalized_rule,
+                n_frames_total=n_frames_total,
+                final_window_start=final_window_start,
+                nearby_waters=nearby_waters,
+            )
+            _write_entry(
+                entries_group,
+                entry,
+                lower_threshold=lower_threshold,
+                upper_threshold=upper_threshold,
+                window_size=window_size,
+            )
+            processed.append(entry)
+
+            if export_snapshots:
+                snapshots.append(
+                    SnapshotModel(
+                        label=label,
+                        xyz=np.asarray(trajectory.xyz[-1], dtype=np.float64),
+                        topology=topology_obj,
+                        trajectory_path=str(trajectory_path),
+                        replica_id=replica_id,
+                    )
+                )
+
+        state_counts = _state_counts_from_store(entries_group)
+
+    summary_path = report_root / f"{_safe_file_stem(experiment_id)}_label_summary.json"
+    pie_chart_path = report_root / f"{_safe_file_stem(experiment_id)}_state_counts.png"
+    _write_summary(
+        summary_path,
+        experiment_id=experiment_id,
+        h5_path=result_file,
+        config=store_config,
+        state_counts=state_counts,
+        processed=len(processed),
+        skipped=len(skipped_entry_keys),
+        overwritten=len(overwritten_entry_keys),
+    )
+    _write_state_pie_chart(pie_chart_path, state_counts=state_counts, experiment_id=experiment_id)
+
+    snapshot_paths = {state: snapshot_root / f"{state}.pdb" for state in STATE_ORDER}
+    if export_snapshots:
+        _export_snapshots(
+            snapshots=snapshots,
+            snapshot_paths=snapshot_paths,
+            center=center_snapshots,
+            align_protein=align_protein,
+        )
+
+    return LabelingResult(
+        experiment_path=experiment_path,
+        h5_path=result_file,
+        processed=tuple(processed),
+        skipped_entry_keys=tuple(skipped_entry_keys),
+        overwritten_entry_keys=tuple(overwritten_entry_keys),
+        state_counts=state_counts,
+        summary_path=summary_path,
+        pie_chart_path=pie_chart_path,
+        snapshot_paths=snapshot_paths,
+    )
+
+
+def _import_mdtraj() -> Any:
+    """Import mdtraj lazily so package import remains lightweight."""
+
+    try:
+        import mdtraj as md
+    except ImportError as exc:  # pragma: no cover - exercised indirectly in user environments.
+        raise ImportError(
+            "label_trajectories requires mdtraj at runtime. Install the optional "
+            "dependency set with `pip install mltsa[md]` or provide mdtraj in the active environment."
+        ) from exc
+    return md
+
+
+def _load_trajectory(md: Any, trajectory_path: Path, topology_path: Path) -> Any:
+    """Load a trajectory through mdtraj using a single shared topology."""
+
+    return md.load(str(trajectory_path), top=str(topology_path))
+
+
+def _normalize_topology_paths(topology: str | Path | Sequence[str | Path], count: int) -> list[Path]:
+    """Broadcast one topology path or validate a per-trajectory topology list."""
+
+    if isinstance(topology, (str, Path)):
+        return [Path(topology)] * count
+
+    topology_list = [Path(path) for path in topology]
+    if len(topology_list) != count:
+        raise ValueError("When topology is a sequence, it must match the number of trajectories.")
+    return topology_list
+
+
+def _normalize_replica_ids(replica_ids: Sequence[str] | None, trajectory_paths: Sequence[Path]) -> list[str]:
+    """Normalize replica ids, defaulting to the trajectory stem."""
+
+    if replica_ids is None:
+        return [_validate_replica_id(path.stem or f"replica_{index:04d}") for index, path in enumerate(trajectory_paths)]
+
+    if len(replica_ids) != len(trajectory_paths):
+        raise ValueError("replica_ids must match the number of trajectories.")
+    return [_validate_replica_id(replica_id) for replica_id in replica_ids]
+
+
+def _validate_replica_id(value: str) -> str:
+    """Reject empty or nested replica ids."""
+
+    cleaned = str(value).strip()
+    if not cleaned:
+        raise ValueError("replica ids must not be empty.")
+    if "/" in cleaned:
+        raise ValueError("replica ids must not contain '/'.")
+    return cleaned
+
+
+def _normalize_rule(rule: str) -> str:
+    """Canonicalize a user-facing rule name."""
+
+    normalized = rule.strip().lower().replace("-", "_").replace(" ", "_")
+    if normalized not in {"sum_distances", "com_distance"}:
+        raise ValueError(f"Unsupported labeling rule {rule!r}.")
+    return normalized
+
+
+def _normalize_path(path: str | Path) -> str:
+    """Normalize a filesystem path for HDF5 entry identity checks."""
+
+    resolved = Path(path).resolve(strict=False)
+    return resolved.as_posix().casefold()
+
+
+def _entry_key(replica_id: str, normalized_trajectory_path: str) -> str:
+    """Build a deterministic HDF5-safe entry key."""
+
+    digest = hashlib.sha1(f"{replica_id}\n{normalized_trajectory_path}".encode("utf-8")).hexdigest()[:16]
+    replica_fragment = re.sub(r"[^0-9A-Za-z]+", "_", replica_id).strip("_") or "replica"
+    return f"{replica_fragment}_{digest}"
+
+
+def _classify_state(mean_value: float, *, lower_threshold: float, upper_threshold: float) -> str:
+    """Map a window mean value to one of the supported MD states."""
+
+    if mean_value <= lower_threshold:
+        return "IN"
+    if mean_value >= upper_threshold:
+        return "OUT"
+    return "TS"
+
+
+def _store_config(
+    *,
+    rule: str,
+    lower_threshold: float,
+    upper_threshold: float,
+    window_size: int,
+    selection_pairs: tuple[SelectionPair, ...],
+    store_waters: bool,
+    n_waters: int,
+) -> dict[str, JSONValue]:
+    """Build canonical store-level metadata."""
+
+    return {
+        "rule": rule,
+        "lower_threshold": float(lower_threshold),
+        "upper_threshold": float(upper_threshold),
+        "window_size": int(window_size),
+        "selection_pairs_json": canonical_json(
+            {
+                "pairs": [{"left": left, "right": right} for left, right in selection_pairs],
+            }
+        ),
+        "store_waters": bool(store_waters),
+        "n_waters": int(n_waters),
+    }
+
+
+def _validate_store_config(label_group: h5py.Group, expected: dict[str, JSONValue], *, append: bool, overwrite: bool) -> None:
+    """Prevent accidental mixing of incompatible labeling configurations."""
+
+    current = {name: _normalize_attr_value(label_group.attrs.get(name)) for name in expected}
+    if current == expected:
+        return
+
+    if append and not overwrite:
+        raise ValueError(
+            "Existing label store configuration does not match the requested labeling setup. "
+            "Use overwrite=True with append=False to rebuild the store from scratch."
+        )
+    if append and overwrite:
+        raise ValueError(
+            "Appending with overwrite=True can replace matching entries, but it cannot safely change the store-wide "
+            "labeling configuration while keeping old entries. Re-run with append=False and overwrite=True."
+        )
+
+
+def _normalize_attr_value(value: object) -> JSONValue:
+    """Convert HDF5 attribute values into plain JSON-compatible Python values."""
+
+    if isinstance(value, np.generic):
+        return value.item()
+    return value  # type: ignore[return-value]
+
+
+def _write_entry(
+    entries_group: h5py.Group,
+    entry: TrajectoryLabelEntry,
+    *,
+    lower_threshold: float,
+    upper_threshold: float,
+    window_size: int,
+) -> None:
+    """Write one trajectory label entry into HDF5."""
+
+    group = entries_group.create_group(entry.entry_key, track_order=True)
+    group.attrs.update(
+        {
+            "kind": "md_trajectory_label",
+            "entry_key": entry.entry_key,
+            "trajectory_path": entry.trajectory_path,
+            "normalized_trajectory_path": entry.normalized_trajectory_path,
+            "topology_path": entry.topology_path,
+            "replica_id": entry.replica_id,
+            "state_label": entry.label,
+            "rule": entry.rule,
+            "mean_value": float(entry.mean_value),
+            "n_frames_total": int(entry.n_frames_total),
+            "final_window_start": int(entry.final_window_start),
+            "window_size": int(window_size),
+            "lower_threshold": float(lower_threshold),
+            "upper_threshold": float(upper_threshold),
+            "waters_stored": bool(entry.nearby_waters is not None),
+        }
+    )
+    replace_dataset(group, "frame_values", entry.frame_values)
+    replace_dataset(group, "component_values", entry.component_values)
+    write_utf8_array(group, "component_labels", entry.component_labels, overwrite=True)
+
+    if entry.nearby_waters is not None:
+        waters_group = ensure_group(group, "nearby_waters")
+        replace_dataset(waters_group, "atom_indices", np.asarray(entry.nearby_waters.atom_indices, dtype=np.int64))
+        replace_dataset(waters_group, "residue_ids", np.asarray(entry.nearby_waters.residue_ids, dtype=np.int64))
+        replace_dataset(waters_group, "mean_distances", np.asarray(entry.nearby_waters.mean_distances, dtype=np.float64))
+        write_utf8_array(waters_group, "residue_names", entry.nearby_waters.residue_names, overwrite=True)
+
+
+def _state_counts_from_store(entries_group: h5py.Group) -> dict[str, int]:
+    """Count stored state labels using only entry metadata."""
+
+    counts: Counter[str] = Counter()
+    for child in entries_group.values():
+        if not isinstance(child, h5py.Group):
+            continue
+        counts[str(child.attrs.get("state_label", ""))] += 1
+    return {state: int(counts.get(state, 0)) for state in STATE_ORDER}
+
+
+def _write_summary(
+    path: Path,
+    *,
+    experiment_id: str,
+    h5_path: Path,
+    config: dict[str, JSONValue],
+    state_counts: dict[str, int],
+    processed: int,
+    skipped: int,
+    overwritten: int,
+) -> None:
+    """Write a JSON summary for a labeling run."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "experiment_id": experiment_id,
+        "h5_path": str(h5_path),
+        "config": config,
+        "state_counts": state_counts,
+        "total_entries": int(sum(state_counts.values())),
+        "processed_entries": int(processed),
+        "skipped_entries": int(skipped),
+        "overwritten_entries": int(overwritten),
+    }
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+
+def _write_state_pie_chart(path: Path, *, state_counts: dict[str, int], experiment_id: str) -> None:
+    """Write a simple pie chart summarizing state counts."""
+
+    import matplotlib
+
+    matplotlib.use("Agg", force=True)
+    import matplotlib.pyplot as plt
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    values = [state_counts.get(state, 0) for state in STATE_ORDER]
+    colors = ["#4c956c", "#bc4749", "#f4a259"]
+
+    figure, axis = plt.subplots(figsize=(4.5, 4.5))
+    total = sum(values)
+    if total == 0:
+        axis.text(0.5, 0.5, "No labels stored", ha="center", va="center")
+        axis.axis("off")
+    else:
+        axis.pie(
+            values,
+            labels=list(STATE_ORDER),
+            colors=colors,
+            autopct=lambda pct: f"{pct:.1f}%" if pct > 0 else "",
+            startangle=90,
+        )
+    axis.set_title(f"State counts: {experiment_id}")
+    figure.tight_layout()
+    figure.savefig(path, dpi=150)
+    plt.close(figure)
+
+
+def _export_snapshots(
+    *,
+    snapshots: Sequence[SnapshotModel],
+    snapshot_paths: dict[str, Path],
+    center: bool,
+    align_protein: bool,
+) -> None:
+    """Export multi-model PDBs for the currently processed snapshots."""
+
+    grouped = {state: [snapshot for snapshot in snapshots if snapshot.label == state] for state in STATE_ORDER}
+    for state, path in snapshot_paths.items():
+        prepared = _prepare_snapshots(grouped[state], center=center, align_protein=align_protein)
+        _write_multi_model_pdb(path, prepared)
+
+
+def _prepare_snapshots(snapshots: Sequence[SnapshotModel], *, center: bool, align_protein: bool) -> list[SnapshotModel]:
+    """Apply optional centering and alignment to snapshots before export."""
+
+    prepared = [
+        SnapshotModel(
+            label=snapshot.label,
+            xyz=np.asarray(snapshot.xyz, dtype=np.float64).copy(),
+            topology=snapshot.topology,
+            trajectory_path=snapshot.trajectory_path,
+            replica_id=snapshot.replica_id,
+        )
+        for snapshot in snapshots
+    ]
+
+    if not prepared:
+        return []
+
+    if center:
+        for index, snapshot in enumerate(prepared):
+            atom_indices = _protein_atom_indices(snapshot.topology)
+            if atom_indices.size == 0:
+                atom_indices = np.arange(snapshot.xyz.shape[0], dtype=np.int64)
+            centroid = snapshot.xyz[atom_indices].mean(axis=0)
+            prepared[index] = SnapshotModel(
+                label=snapshot.label,
+                xyz=snapshot.xyz - centroid,
+                topology=snapshot.topology,
+                trajectory_path=snapshot.trajectory_path,
+                replica_id=snapshot.replica_id,
+            )
+
+    if align_protein and len(prepared) > 1:
+        reference = prepared[0]
+        atom_indices = _protein_atom_indices(reference.topology)
+        if atom_indices.size == 0:
+            atom_indices = np.arange(reference.xyz.shape[0], dtype=np.int64)
+        reference_subset = reference.xyz[atom_indices]
+        ref_center = reference_subset.mean(axis=0)
+        reference_subset = reference_subset - ref_center
+
+        aligned: list[SnapshotModel] = [reference]
+        for snapshot in prepared[1:]:
+            moving_subset = snapshot.xyz[atom_indices]
+            moving_center = moving_subset.mean(axis=0)
+            centered_moving = moving_subset - moving_center
+            rotation = _kabsch(centered_moving, reference_subset)
+            aligned_xyz = (snapshot.xyz - moving_center) @ rotation + ref_center
+            aligned.append(
+                SnapshotModel(
+                    label=snapshot.label,
+                    xyz=aligned_xyz,
+                    topology=snapshot.topology,
+                    trajectory_path=snapshot.trajectory_path,
+                    replica_id=snapshot.replica_id,
+                )
+            )
+        prepared = aligned
+
+    return prepared
+
+
+def _protein_atom_indices(topology: Any) -> np.ndarray:
+    """Return protein atom indices when the topology can identify them."""
+
+    indices = [
+        int(atom.index)
+        for atom in topology.atoms
+        if bool(getattr(atom.residue, "is_protein", False))
+    ]
+    return np.asarray(indices, dtype=np.int64)
+
+
+def _kabsch(moving: np.ndarray, reference: np.ndarray) -> np.ndarray:
+    """Compute an optimal rotation from ``moving`` to ``reference``."""
+
+    if moving.shape[0] < 2:
+        return np.eye(3, dtype=np.float64)
+
+    covariance = moving.T @ reference
+    left, _, right_t = np.linalg.svd(covariance)
+    correction = np.eye(3, dtype=np.float64)
+    if np.linalg.det(left @ right_t) < 0.0:
+        correction[-1, -1] = -1.0
+    return left @ correction @ right_t
+
+
+def _write_multi_model_pdb(path: Path, snapshots: Sequence[SnapshotModel]) -> None:
+    """Write a lightweight multi-model PDB file from single-frame snapshots."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        handle.write("REMARK Generated by mltsa.md.label\n")
+        if not snapshots:
+            handle.write("END\n")
+            return
+
+        for model_index, snapshot in enumerate(snapshots, start=1):
+            handle.write(f"MODEL     {model_index}\n")
+            for atom in snapshot.topology.atoms:
+                residue = atom.residue
+                serial = int(getattr(atom, "serial", atom.index + 1))
+                name = str(getattr(atom, "name", "X"))[:4]
+                resname = str(getattr(residue, "name", "UNK"))[:3]
+                chain_id = _chain_id(residue)
+                residue_id = int(getattr(residue, "resSeq", getattr(residue, "index", 1)))
+                x, y, z = np.asarray(snapshot.xyz[int(atom.index)], dtype=np.float64) * 10.0
+                element = str(getattr(getattr(atom, "element", None), "symbol", name[:1])).strip()[:2]
+                handle.write(
+                    f"ATOM  {serial:5d} {name:<4s} {resname:>3s} {chain_id}{residue_id:4d}    "
+                    f"{x:8.3f}{y:8.3f}{z:8.3f}  1.00  0.00          {element:>2s}\n"
+                )
+            handle.write("ENDMDL\n")
+        handle.write("END\n")
+
+
+def _chain_id(residue: Any) -> str:
+    """Return a PDB-compatible chain identifier."""
+
+    chain = getattr(residue, "chain", None)
+    index = int(getattr(chain, "index", 0))
+    return "ABCDEFGHIJKLMNOPQRSTUVWXYZ"[index % 26]
+
+
+def _safe_file_stem(value: str) -> str:
+    """Return a filesystem-safe identifier fragment."""
+
+    cleaned = re.sub(r"[^0-9A-Za-z._-]+", "_", value.strip())
+    return cleaned or "labels"
+
+
+__all__ = ["LabelingResult", "TrajectoryLabelEntry", "label_trajectories"]

--- a/src/mltsa/models/__init__.py
+++ b/src/mltsa/models/__init__.py
@@ -1,17 +1,51 @@
 """Model abstractions and training entry points for mltsa."""
 
-from .sklearn_wrappers import (
-    ExtraTrees,
-    GradientBoosting,
-    HistGradientBoosting,
-    RandomForest,
-    get_model,
-)
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from .sklearn_wrappers import ExtraTrees, GradientBoosting, HistGradientBoosting, RandomForest
+from .torch import CNN1D, LSTM, MLP
+
+
+def get_model(name: str, **kwargs: Any) -> object:
+    """Build a supported sklearn or PyTorch model wrapper by name."""
+
+    normalized = name.strip().lower().replace("-", "_").replace(" ", "_")
+    factories: dict[str, Callable[..., object]] = {
+        "random_forest": RandomForest,
+        "rf": RandomForest,
+        "gradient_boosting": GradientBoosting,
+        "gb": GradientBoosting,
+        "gbdt": GradientBoosting,
+        "hist_gradient_boosting": HistGradientBoosting,
+        "hist_gbdt": HistGradientBoosting,
+        "hgb": HistGradientBoosting,
+        "extra_trees": ExtraTrees,
+        "et": ExtraTrees,
+        "mlp": MLP,
+        "torch_mlp": MLP,
+        "lstm": LSTM,
+        "torch_lstm": LSTM,
+        "cnn1d": CNN1D,
+        "cnn_1d": CNN1D,
+        "cnn": CNN1D,
+        "torch_cnn1d": CNN1D,
+    }
+    try:
+        return factories[normalized](**kwargs)
+    except KeyError as exc:
+        supported = ", ".join(sorted(factories))
+        raise ValueError(f"Unsupported model name {name!r}. Supported names: {supported}.") from exc
+
 
 __all__ = [
+    "CNN1D",
     "ExtraTrees",
     "GradientBoosting",
     "HistGradientBoosting",
+    "LSTM",
+    "MLP",
     "RandomForest",
     "get_model",
 ]

--- a/src/mltsa/models/__init__.py
+++ b/src/mltsa/models/__init__.py
@@ -1,3 +1,17 @@
 """Model abstractions and training entry points for mltsa."""
 
-__all__: list[str] = []
+from .sklearn_wrappers import (
+    ExtraTrees,
+    GradientBoosting,
+    HistGradientBoosting,
+    RandomForest,
+    get_model,
+)
+
+__all__ = [
+    "ExtraTrees",
+    "GradientBoosting",
+    "HistGradientBoosting",
+    "RandomForest",
+    "get_model",
+]

--- a/src/mltsa/models/sklearn_wrappers.py
+++ b/src/mltsa/models/sklearn_wrappers.py
@@ -1,0 +1,132 @@
+"""Small sklearn classifier wrappers used by mltsa."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from sklearn.ensemble import (
+    ExtraTreesClassifier,
+    GradientBoostingClassifier,
+    HistGradientBoostingClassifier,
+    RandomForestClassifier,
+)
+
+
+@dataclass(slots=True)
+class _SklearnModelWrapper:
+    """Thin wrapper around a sklearn estimator with a stable mltsa-facing API."""
+
+    estimator: Any
+    model_name: str
+
+    def fit(self, X: Any, y: Any) -> _SklearnModelWrapper:
+        """Fit the wrapped estimator and return ``self``."""
+
+        self.estimator.fit(X, y)
+        return self
+
+    def predict(self, X: Any) -> Any:
+        """Delegate prediction to the wrapped estimator."""
+
+        return self.estimator.predict(X)
+
+    def predict_proba(self, X: Any) -> Any:
+        """Delegate probability prediction when supported."""
+
+        if not hasattr(self.estimator, "predict_proba"):
+            raise AttributeError(f"{self.model_name} does not support predict_proba().")
+        return self.estimator.predict_proba(X)
+
+    def score(self, X: Any, y: Any) -> float:
+        """Delegate scoring to the wrapped estimator."""
+
+        return float(self.estimator.score(X, y))
+
+    def get_params(self, deep: bool = True) -> dict[str, Any]:
+        """Expose wrapped estimator parameters."""
+
+        return dict(self.estimator.get_params(deep=deep))
+
+    def set_params(self, **params: Any) -> _SklearnModelWrapper:
+        """Update wrapped estimator parameters and return ``self``."""
+
+        self.estimator.set_params(**params)
+        return self
+
+    def __getattr__(self, name: str) -> Any:
+        """Delegate unknown attributes to the wrapped estimator."""
+
+        return getattr(self.estimator, name)
+
+
+class RandomForest(_SklearnModelWrapper):
+    """Random forest classifier wrapper."""
+
+    canonical_name: ClassVar[str] = "random_forest"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("random_state", 0)
+        super().__init__(RandomForestClassifier(**kwargs), self.canonical_name)
+
+
+class GradientBoosting(_SklearnModelWrapper):
+    """Gradient boosting classifier wrapper."""
+
+    canonical_name: ClassVar[str] = "gradient_boosting"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("random_state", 0)
+        super().__init__(GradientBoostingClassifier(**kwargs), self.canonical_name)
+
+
+class HistGradientBoosting(_SklearnModelWrapper):
+    """Histogram-based gradient boosting classifier wrapper."""
+
+    canonical_name: ClassVar[str] = "hist_gradient_boosting"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("random_state", 0)
+        super().__init__(HistGradientBoostingClassifier(**kwargs), self.canonical_name)
+
+
+class ExtraTrees(_SklearnModelWrapper):
+    """Extra trees classifier wrapper."""
+
+    canonical_name: ClassVar[str] = "extra_trees"
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("random_state", 0)
+        super().__init__(ExtraTreesClassifier(**kwargs), self.canonical_name)
+
+
+def get_model(name: str, **kwargs: Any) -> _SklearnModelWrapper:
+    """Build a supported sklearn wrapper from a short model name."""
+
+    normalized = name.strip().lower().replace("-", "_").replace(" ", "_")
+    factories = {
+        "random_forest": RandomForest,
+        "rf": RandomForest,
+        "gradient_boosting": GradientBoosting,
+        "gb": GradientBoosting,
+        "gbdt": GradientBoosting,
+        "hist_gradient_boosting": HistGradientBoosting,
+        "hist_gbdt": HistGradientBoosting,
+        "hgb": HistGradientBoosting,
+        "extra_trees": ExtraTrees,
+        "et": ExtraTrees,
+    }
+    try:
+        return factories[normalized](**kwargs)
+    except KeyError as exc:
+        supported = ", ".join(sorted(factories))
+        raise ValueError(f"Unsupported model name {name!r}. Supported names: {supported}.") from exc
+
+
+__all__ = [
+    "ExtraTrees",
+    "GradientBoosting",
+    "HistGradientBoosting",
+    "RandomForest",
+    "get_model",
+]

--- a/src/mltsa/models/torch/__init__.py
+++ b/src/mltsa/models/torch/__init__.py
@@ -1,0 +1,5 @@
+"""PyTorch model wrappers for lightweight time-series classification."""
+
+from .base import CNN1D, LSTM, MLP, TorchClassifierBase
+
+__all__ = ["CNN1D", "LSTM", "MLP", "TorchClassifierBase"]

--- a/src/mltsa/models/torch/base.py
+++ b/src/mltsa/models/torch/base.py
@@ -1,0 +1,335 @@
+"""High-level PyTorch wrappers for time-series classification."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Any, TypeVar
+
+import numpy as np
+import torch
+from torch import nn
+
+from .datasets import encode_targets, ensure_feature_array
+from .modules import CNN1DClassifier, LSTMClassifier, MLPClassifier
+from .trainer import TorchTrainer, TrainerConfig
+
+TorchModelT = TypeVar("TorchModelT", bound="TorchClassifierBase")
+
+
+class TorchClassifierBase(ABC):
+    """Base wrapper exposing a small sklearn-like API for torch models."""
+
+    canonical_name = "torch_model"
+
+    def __init__(
+        self,
+        *,
+        epochs: int = 20,
+        batch_size: int = 32,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 0.0,
+        random_state: int = 0,
+        device: str = "cpu",
+    ) -> None:
+        self.epochs = int(epochs)
+        self.batch_size = int(batch_size)
+        self.learning_rate = float(learning_rate)
+        self.weight_decay = float(weight_decay)
+        self.random_state = int(random_state)
+        self.device = str(device)
+
+        self.model_name = self.canonical_name
+        self.module_: nn.Module | None = None
+        self.classes_: np.ndarray | None = None
+        self.input_shape_: tuple[int, int] | None = None
+        self.training_loss_: list[float] = []
+
+    def fit(self, X: object, y: object) -> "TorchClassifierBase":
+        """Fit the wrapped torch classifier and return ``self``."""
+
+        features = ensure_feature_array(X)
+        classes, encoded_targets = encode_targets(y, features.shape[0])
+        input_shape = (int(features.shape[1]), int(features.shape[2]))
+
+        self.module_ = self._build_module(input_shape, int(classes.shape[0]))
+        self.classes_ = classes
+        self.input_shape_ = input_shape
+        self.training_loss_ = self._trainer().fit(self.module_, features, encoded_targets)
+        return self
+
+    def predict(self, X: object) -> np.ndarray:
+        """Predict class labels for the provided samples."""
+
+        probabilities = self.predict_proba(X)
+        indices = probabilities.argmax(axis=1)
+        classes = self._require_classes()
+        return classes[indices]
+
+    def predict_proba(self, X: object) -> np.ndarray:
+        """Predict class probabilities for the provided samples."""
+
+        module = self._require_module()
+        features = ensure_feature_array(X)
+        self._validate_input_shape(features)
+        return self._trainer().predict_proba(module, features)
+
+    def score(self, X: object, y: object) -> float:
+        """Return simple classification accuracy on the provided samples."""
+
+        predictions = self.predict(X)
+        targets = np.asarray(y)
+        if targets.ndim != 1 or targets.shape[0] != predictions.shape[0]:
+            raise ValueError("y must be one-dimensional and match the number of samples in X.")
+        return float(np.mean(predictions == targets))
+
+    def save(self, path: str | Path) -> Path:
+        """Persist model weights and wrapper configuration to disk."""
+
+        module = self._require_module()
+        classes = self._require_classes()
+        input_shape = self._require_input_shape()
+        target_path = Path(path)
+        payload = {
+            "class_name": type(self).__name__,
+            "canonical_name": self.canonical_name,
+            "init_params": self._get_init_params(),
+            "classes": classes.tolist(),
+            "input_shape": input_shape,
+            "state_dict": module.state_dict(),
+        }
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        with target_path.open("wb") as buffer:
+            torch.save(payload, buffer)
+        return target_path
+
+    @classmethod
+    def load(cls: type[TorchModelT], path: str | Path) -> TorchModelT:
+        """Load a saved wrapper instance from disk."""
+
+        source_path = Path(path)
+        with source_path.open("rb") as buffer:
+            payload = torch.load(buffer, map_location="cpu", weights_only=False)
+        model = cls(**payload["init_params"])
+        input_shape = tuple(int(value) for value in payload["input_shape"])
+        classes = np.asarray(payload["classes"])
+
+        model.module_ = model._build_module(input_shape, int(classes.shape[0]))
+        model.module_.load_state_dict(payload["state_dict"])
+        model.module_.eval()
+        model.classes_ = classes
+        model.input_shape_ = input_shape
+        return model
+
+    def _trainer(self) -> TorchTrainer:
+        """Construct a trainer for the current wrapper settings."""
+
+        return TorchTrainer(
+            TrainerConfig(
+                epochs=self.epochs,
+                batch_size=self.batch_size,
+                learning_rate=self.learning_rate,
+                weight_decay=self.weight_decay,
+                random_state=self.random_state,
+                device=self.device,
+            )
+        )
+
+    def _validate_input_shape(self, features: np.ndarray) -> None:
+        """Ensure inference data matches the training-time feature shape."""
+
+        expected = self._require_input_shape()
+        actual = (int(features.shape[1]), int(features.shape[2]))
+        if actual != expected:
+            raise ValueError(f"Expected input shape {expected}, received {actual}.")
+
+    def _require_module(self) -> nn.Module:
+        """Return the fitted torch module or raise a clear error."""
+
+        if self.module_ is None:
+            raise RuntimeError("This model has not been fitted yet.")
+        return self.module_
+
+    def _require_classes(self) -> np.ndarray:
+        """Return the fitted class labels or raise a clear error."""
+
+        if self.classes_ is None:
+            raise RuntimeError("This model has not been fitted yet.")
+        return self.classes_
+
+    def _require_input_shape(self) -> tuple[int, int]:
+        """Return the fitted input shape or raise a clear error."""
+
+        if self.input_shape_ is None:
+            raise RuntimeError("This model has not been fitted yet.")
+        return self.input_shape_
+
+    @abstractmethod
+    def _build_module(self, input_shape: tuple[int, int], n_classes: int) -> nn.Module:
+        """Build a fresh torch module for fitting or loading."""
+
+    @abstractmethod
+    def _get_init_params(self) -> dict[str, Any]:
+        """Return constructor arguments needed to recreate the wrapper."""
+
+
+class MLP(TorchClassifierBase):
+    """Lightweight multilayer perceptron classifier."""
+
+    canonical_name = "mlp"
+
+    def __init__(
+        self,
+        *,
+        hidden_sizes: tuple[int, ...] = (64, 32),
+        dropout: float = 0.0,
+        epochs: int = 20,
+        batch_size: int = 32,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 0.0,
+        random_state: int = 0,
+        device: str = "cpu",
+    ) -> None:
+        super().__init__(
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            weight_decay=weight_decay,
+            random_state=random_state,
+            device=device,
+        )
+        self.hidden_sizes = tuple(int(value) for value in hidden_sizes)
+        self.dropout = float(dropout)
+
+    def _build_module(self, input_shape: tuple[int, int], n_classes: int) -> nn.Module:
+        return MLPClassifier(
+            input_shape=input_shape,
+            n_classes=n_classes,
+            hidden_sizes=self.hidden_sizes,
+            dropout=self.dropout,
+        )
+
+    def _get_init_params(self) -> dict[str, Any]:
+        return {
+            "hidden_sizes": self.hidden_sizes,
+            "dropout": self.dropout,
+            "epochs": self.epochs,
+            "batch_size": self.batch_size,
+            "learning_rate": self.learning_rate,
+            "weight_decay": self.weight_decay,
+            "random_state": self.random_state,
+            "device": self.device,
+        }
+
+
+class LSTM(TorchClassifierBase):
+    """LSTM-based sequence classifier."""
+
+    canonical_name = "lstm"
+
+    def __init__(
+        self,
+        *,
+        hidden_size: int = 32,
+        num_layers: int = 1,
+        dropout: float = 0.0,
+        bidirectional: bool = False,
+        epochs: int = 20,
+        batch_size: int = 32,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 0.0,
+        random_state: int = 0,
+        device: str = "cpu",
+    ) -> None:
+        super().__init__(
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            weight_decay=weight_decay,
+            random_state=random_state,
+            device=device,
+        )
+        self.hidden_size = int(hidden_size)
+        self.num_layers = int(num_layers)
+        self.dropout = float(dropout)
+        self.bidirectional = bool(bidirectional)
+
+    def _build_module(self, input_shape: tuple[int, int], n_classes: int) -> nn.Module:
+        return LSTMClassifier(
+            input_shape=input_shape,
+            n_classes=n_classes,
+            hidden_size=self.hidden_size,
+            num_layers=self.num_layers,
+            dropout=self.dropout,
+            bidirectional=self.bidirectional,
+        )
+
+    def _get_init_params(self) -> dict[str, Any]:
+        return {
+            "hidden_size": self.hidden_size,
+            "num_layers": self.num_layers,
+            "dropout": self.dropout,
+            "bidirectional": self.bidirectional,
+            "epochs": self.epochs,
+            "batch_size": self.batch_size,
+            "learning_rate": self.learning_rate,
+            "weight_decay": self.weight_decay,
+            "random_state": self.random_state,
+            "device": self.device,
+        }
+
+
+class CNN1D(TorchClassifierBase):
+    """Compact 1D convolutional sequence classifier."""
+
+    canonical_name = "cnn1d"
+
+    def __init__(
+        self,
+        *,
+        channels: int = 32,
+        kernel_size: int = 3,
+        dropout: float = 0.0,
+        epochs: int = 20,
+        batch_size: int = 32,
+        learning_rate: float = 1e-3,
+        weight_decay: float = 0.0,
+        random_state: int = 0,
+        device: str = "cpu",
+    ) -> None:
+        super().__init__(
+            epochs=epochs,
+            batch_size=batch_size,
+            learning_rate=learning_rate,
+            weight_decay=weight_decay,
+            random_state=random_state,
+            device=device,
+        )
+        self.channels = int(channels)
+        self.kernel_size = int(kernel_size)
+        self.dropout = float(dropout)
+
+    def _build_module(self, input_shape: tuple[int, int], n_classes: int) -> nn.Module:
+        return CNN1DClassifier(
+            input_shape=input_shape,
+            n_classes=n_classes,
+            channels=self.channels,
+            kernel_size=self.kernel_size,
+            dropout=self.dropout,
+        )
+
+    def _get_init_params(self) -> dict[str, Any]:
+        return {
+            "channels": self.channels,
+            "kernel_size": self.kernel_size,
+            "dropout": self.dropout,
+            "epochs": self.epochs,
+            "batch_size": self.batch_size,
+            "learning_rate": self.learning_rate,
+            "weight_decay": self.weight_decay,
+            "random_state": self.random_state,
+            "device": self.device,
+        }
+
+
+__all__ = ["CNN1D", "LSTM", "MLP", "TorchClassifierBase"]

--- a/src/mltsa/models/torch/datasets.py
+++ b/src/mltsa/models/torch/datasets.py
@@ -1,0 +1,59 @@
+"""Dataset helpers for PyTorch time-series models."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import torch
+from torch.utils.data import Dataset
+
+
+def ensure_feature_array(X: Any) -> np.ndarray:
+    """Normalize feature input to ``(n_samples, n_steps, n_features)``."""
+
+    features = np.asarray(X, dtype=np.float32)
+    if features.ndim == 2:
+        features = features[:, None, :]
+    elif features.ndim != 3:
+        raise ValueError("X must have shape (n_samples, n_features) or (n_samples, n_steps, n_features).")
+
+    if features.shape[0] == 0:
+        raise ValueError("X must contain at least one sample.")
+    return np.ascontiguousarray(features, dtype=np.float32)
+
+
+def encode_targets(y: Any, n_samples: int) -> tuple[np.ndarray, np.ndarray]:
+    """Return sorted unique classes and encoded integer targets."""
+
+    targets = np.asarray(y)
+    if targets.ndim != 1:
+        raise ValueError("y must be one-dimensional.")
+    if targets.shape[0] != n_samples:
+        raise ValueError("y length must match the number of samples in X.")
+
+    classes, encoded = np.unique(targets, return_inverse=True)
+    if classes.size < 2:
+        raise ValueError("At least two classes are required for classification.")
+    return classes, encoded.astype(np.int64, copy=False)
+
+
+class TimeSeriesDataset(Dataset[tuple[torch.Tensor, torch.Tensor]]):
+    """Minimal dataset backed by in-memory numpy arrays."""
+
+    def __init__(self, X: np.ndarray, y: np.ndarray) -> None:
+        self.features = torch.from_numpy(np.asarray(X, dtype=np.float32))
+        self.targets = torch.from_numpy(np.asarray(y, dtype=np.int64))
+
+    def __len__(self) -> int:
+        """Return the sample count."""
+
+        return int(self.targets.shape[0])
+
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return a single feature-target pair."""
+
+        return self.features[index], self.targets[index]
+
+
+__all__ = ["TimeSeriesDataset", "encode_targets", "ensure_feature_array"]

--- a/src/mltsa/models/torch/modules.py
+++ b/src/mltsa/models/torch/modules.py
@@ -1,0 +1,117 @@
+"""Neural network modules used by the mltsa torch wrappers."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import torch
+from torch import nn
+
+
+class MLPClassifier(nn.Module):
+    """Simple multilayer perceptron over flattened time-series features."""
+
+    def __init__(
+        self,
+        input_shape: tuple[int, int],
+        n_classes: int,
+        *,
+        hidden_sizes: Sequence[int] = (64, 32),
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        input_dim = input_shape[0] * input_shape[1]
+        layers: list[nn.Module] = []
+        previous_dim = input_dim
+
+        for hidden_size in hidden_sizes:
+            layers.append(nn.Linear(previous_dim, int(hidden_size)))
+            layers.append(nn.ReLU())
+            if dropout > 0.0:
+                layers.append(nn.Dropout(dropout))
+            previous_dim = int(hidden_size)
+
+        layers.append(nn.Linear(previous_dim, n_classes))
+        self.network = nn.Sequential(*layers)
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        """Return class logits for a batch of time-series samples."""
+
+        flattened = torch.flatten(X, start_dim=1)
+        return self.network(flattened)
+
+
+class LSTMClassifier(nn.Module):
+    """Single-head LSTM classifier using the final hidden state."""
+
+    def __init__(
+        self,
+        input_shape: tuple[int, int],
+        n_classes: int,
+        *,
+        hidden_size: int = 32,
+        num_layers: int = 1,
+        dropout: float = 0.0,
+        bidirectional: bool = False,
+    ) -> None:
+        super().__init__()
+        _, n_features = input_shape
+        effective_dropout = dropout if num_layers > 1 else 0.0
+        self.bidirectional = bidirectional
+        self.encoder = nn.LSTM(
+            input_size=n_features,
+            hidden_size=hidden_size,
+            num_layers=num_layers,
+            dropout=effective_dropout,
+            batch_first=True,
+            bidirectional=bidirectional,
+        )
+        output_width = hidden_size * (2 if bidirectional else 1)
+        self.classifier = nn.Linear(output_width, n_classes)
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        """Return class logits for a batch of time-series samples."""
+
+        _, (hidden_state, _) = self.encoder(X)
+        if self.bidirectional:
+            last_hidden = torch.cat((hidden_state[-2], hidden_state[-1]), dim=1)
+        else:
+            last_hidden = hidden_state[-1]
+        return self.classifier(last_hidden)
+
+
+class CNN1DClassifier(nn.Module):
+    """Compact 1D convolutional classifier over sequence steps."""
+
+    def __init__(
+        self,
+        input_shape: tuple[int, int],
+        n_classes: int,
+        *,
+        channels: int = 32,
+        kernel_size: int = 3,
+        dropout: float = 0.0,
+    ) -> None:
+        super().__init__()
+        _, n_features = input_shape
+        padding = kernel_size // 2
+        self.encoder = nn.Sequential(
+            nn.Conv1d(n_features, channels, kernel_size=kernel_size, padding=padding),
+            nn.ReLU(),
+            nn.Conv1d(channels, channels, kernel_size=kernel_size, padding=padding),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool1d(1),
+        )
+        self.dropout = nn.Dropout(dropout) if dropout > 0.0 else nn.Identity()
+        self.classifier = nn.Linear(channels, n_classes)
+
+    def forward(self, X: torch.Tensor) -> torch.Tensor:
+        """Return class logits for a batch of time-series samples."""
+
+        channels_first = X.transpose(1, 2)
+        encoded = self.encoder(channels_first)
+        flattened = torch.flatten(encoded, start_dim=1)
+        return self.classifier(self.dropout(flattened))
+
+
+__all__ = ["CNN1DClassifier", "LSTMClassifier", "MLPClassifier"]

--- a/src/mltsa/models/torch/trainer.py
+++ b/src/mltsa/models/torch/trainer.py
@@ -1,0 +1,107 @@
+"""Training utilities for mltsa torch classifiers."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+
+import numpy as np
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+
+from .datasets import TimeSeriesDataset, ensure_feature_array
+
+
+def set_random_seed(seed: int) -> None:
+    """Seed Python, NumPy, and PyTorch for reproducible tiny experiments."""
+
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+
+@dataclass(slots=True)
+class TrainerConfig:
+    """Configuration for the simple supervised training loop."""
+
+    epochs: int = 20
+    batch_size: int = 32
+    learning_rate: float = 1e-3
+    weight_decay: float = 0.0
+    random_state: int = 0
+    device: str = "cpu"
+
+
+class TorchTrainer:
+    """Small trainer for CPU-friendly sequence classification experiments."""
+
+    def __init__(self, config: TrainerConfig | None = None) -> None:
+        self.config = config or TrainerConfig()
+
+    def fit(self, module: nn.Module, X: np.ndarray, y: np.ndarray) -> list[float]:
+        """Fit a module on encoded targets and return per-epoch mean losses."""
+
+        set_random_seed(self.config.random_state)
+        device = self._resolve_device()
+        module.to(device)
+        module.train()
+
+        dataset = TimeSeriesDataset(X, y)
+        batch_size = min(self.config.batch_size, len(dataset))
+        loader = DataLoader(dataset, batch_size=batch_size, shuffle=True)
+        optimizer = torch.optim.Adam(
+            module.parameters(),
+            lr=self.config.learning_rate,
+            weight_decay=self.config.weight_decay,
+        )
+        criterion = nn.CrossEntropyLoss()
+        history: list[float] = []
+
+        for _ in range(self.config.epochs):
+            running_loss = 0.0
+            sample_count = 0
+            for features, targets in loader:
+                features = features.to(device)
+                targets = targets.to(device)
+
+                optimizer.zero_grad(set_to_none=True)
+                logits = module(features)
+                loss = criterion(logits, targets)
+                loss.backward()
+                optimizer.step()
+
+                batch_size = int(targets.shape[0])
+                running_loss += float(loss.detach().cpu()) * batch_size
+                sample_count += batch_size
+
+            history.append(running_loss / max(sample_count, 1))
+
+        module.to("cpu")
+        module.eval()
+        return history
+
+    @torch.no_grad()
+    def predict_proba(self, module: nn.Module, X: object) -> np.ndarray:
+        """Return class probabilities for a batch of feature arrays."""
+
+        features = torch.from_numpy(ensure_feature_array(X))
+        device = self._resolve_device()
+        module.to(device)
+        module.eval()
+        logits = module(features.to(device))
+        probabilities = torch.softmax(logits, dim=1).cpu().numpy()
+        module.to("cpu")
+        return probabilities
+
+    def _resolve_device(self) -> torch.device:
+        """Return the configured torch device."""
+
+        if self.config.device == "cuda" and not torch.cuda.is_available():
+            raise RuntimeError("CUDA was requested but is not available.")
+        return torch.device(self.config.device)
+
+
+__all__ = ["TorchTrainer", "TrainerConfig", "set_random_seed"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package for local helpers and fixtures."""

--- a/tests/_md_fakes.py
+++ b/tests/_md_fakes.py
@@ -1,0 +1,175 @@
+"""Shared fake mdtraj helpers for MD unit tests."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+
+
+@dataclass(frozen=True, slots=True)
+class FakeElement:
+    symbol: str
+    mass: float
+
+
+@dataclass(frozen=True, slots=True)
+class FakeChain:
+    index: int
+
+
+@dataclass(frozen=True, slots=True)
+class FakeResidue:
+    name: str
+    index: int
+    resSeq: int
+    chain: FakeChain
+    is_water: bool = False
+    is_protein: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class FakeAtom:
+    index: int
+    name: str
+    residue: FakeResidue
+    element: FakeElement
+    serial: int
+
+
+class FakeTopology:
+    """Small subset of the mdtraj topology interface used by mltsa tests."""
+
+    def __init__(self, atoms: list[FakeAtom]) -> None:
+        self.atoms = atoms
+        seen_residues: list[FakeResidue] = []
+        seen_ids: set[int] = set()
+        for atom in atoms:
+            residue = atom.residue
+            marker = id(residue)
+            if marker not in seen_ids:
+                seen_residues.append(residue)
+                seen_ids.add(marker)
+        self.residues = tuple(seen_residues)
+
+    def select(self, query: str) -> np.ndarray:
+        normalized = " ".join(query.strip().split()).lower()
+        if normalized.startswith("index "):
+            return np.asarray([int(normalized.split()[1])], dtype=np.int64)
+        if normalized == "protein":
+            return np.asarray([atom.index for atom in self.atoms if atom.residue.is_protein], dtype=np.int64)
+        if normalized == "resname lig":
+            return np.asarray([atom.index for atom in self.atoms if atom.residue.name.upper() == "LIG"], dtype=np.int64)
+        if normalized in {"water", "resname hoh", "water and name o", "name o and water"}:
+            return np.asarray(
+                [
+                    atom.index
+                    for atom in self.atoms
+                    if atom.residue.is_water and (normalized in {"water", "resname hoh"} or atom.name.upper().startswith("O"))
+                ],
+                dtype=np.int64,
+            )
+        raise KeyError(f"Unsupported fake selection: {query!r}")
+
+
+class FakeTrajectory:
+    """Small trajectory container with the attributes needed by the MD modules."""
+
+    def __init__(self, xyz: np.ndarray, topology: FakeTopology) -> None:
+        self.xyz = np.asarray(xyz, dtype=np.float64)
+        self.topology = topology
+        self.top = topology
+
+
+class FakeMdtraj:
+    """Registry-backed fake mdtraj module used for tests."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, FakeTrajectory] = {}
+
+    def register(self, path: Path, trajectory: FakeTrajectory) -> None:
+        self._registry[path.resolve().as_posix().casefold()] = trajectory
+
+    def load(self, path: str, top: str | None = None) -> FakeTrajectory:
+        key = Path(path).resolve().as_posix().casefold()
+        trajectory = self._registry[key]
+        if top is None:
+            return trajectory
+        topology_key = Path(top).resolve().as_posix().casefold()
+        topology = self._registry[topology_key].topology
+        return FakeTrajectory(np.asarray(trajectory.xyz, dtype=np.float64), topology)
+
+
+def build_fake_md_module() -> FakeMdtraj:
+    """Construct a reusable fake mdtraj module and topology."""
+
+    chain = FakeChain(index=0)
+    residues = [
+        FakeResidue(name="ALA", index=0, resSeq=1, chain=chain, is_protein=True),
+        FakeResidue(name="GLY", index=1, resSeq=2, chain=chain, is_protein=True),
+        FakeResidue(name="LIG", index=2, resSeq=3, chain=chain),
+        FakeResidue(name="HOH", index=3, resSeq=10, chain=chain, is_water=True),
+        FakeResidue(name="HOH", index=4, resSeq=11, chain=chain, is_water=True),
+    ]
+    atoms = [
+        FakeAtom(index=0, name="CA", residue=residues[0], element=FakeElement("C", 12.0), serial=1),
+        FakeAtom(index=1, name="CB", residue=residues[1], element=FakeElement("C", 12.0), serial=2),
+        FakeAtom(index=2, name="C1", residue=residues[2], element=FakeElement("C", 12.0), serial=3),
+        FakeAtom(index=3, name="O", residue=residues[3], element=FakeElement("O", 16.0), serial=4),
+        FakeAtom(index=4, name="O", residue=residues[4], element=FakeElement("O", 16.0), serial=5),
+    ]
+    topology = FakeTopology(atoms)
+    topology_trajectory = FakeTrajectory(np.zeros((1, len(atoms), 3), dtype=np.float64), topology)
+
+    fake_md = FakeMdtraj()
+    fake_md.topology = topology_trajectory
+    return fake_md
+
+
+def make_xyz(
+    ligand_x: list[float],
+    *,
+    protein_a_x: float = 0.0,
+    protein_b_x: float = 1.0,
+    water_near_x: float = 0.7,
+    water_far_x: float = 4.0,
+) -> np.ndarray:
+    """Build a tiny deterministic trajectory geometry for tests."""
+
+    xyz = np.zeros((len(ligand_x), 5, 3), dtype=np.float64)
+    xyz[:, 0, 0] = protein_a_x
+    xyz[:, 1, 0] = protein_b_x
+    xyz[:, 2, 0] = np.asarray(ligand_x, dtype=np.float64)
+    xyz[:, 3, 0] = water_near_x
+    xyz[:, 4, 0] = water_far_x
+    return xyz
+
+
+def register_fake_inputs(
+    workspace_tmp_dir: Path,
+    fake_md_module: FakeMdtraj,
+    names_to_xyz: dict[str, np.ndarray],
+) -> tuple[Path, dict[str, Path]]:
+    """Register topology and trajectory paths in the fake mdtraj registry."""
+
+    topology_path = workspace_tmp_dir / "topology.pdb"
+    topology_path.write_text("fake topology\n", encoding="utf-8")
+    fake_md_module.register(topology_path, fake_md_module.topology)
+
+    trajectory_paths: dict[str, Path] = {}
+    for name, xyz in names_to_xyz.items():
+        path = workspace_tmp_dir / f"{name}.dcd"
+        path.write_text("fake trajectory\n", encoding="utf-8")
+        fake_md_module.register(path, FakeTrajectory(xyz, fake_md_module.topology.topology))
+        trajectory_paths[name] = path
+
+    return topology_path, trajectory_paths
+
+
+__all__ = [
+    "FakeMdtraj",
+    "build_fake_md_module",
+    "make_xyz",
+    "register_fake_inputs",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import shutil
 import sys
-import tempfile
+import uuid
 from pathlib import Path
 
 import pytest
@@ -22,7 +22,8 @@ def workspace_tmp_dir() -> Path:
     base_dir = Path(__file__).resolve().parents[1] / ".test_tmp"
     base_dir.mkdir(exist_ok=True)
 
-    temp_dir = Path(tempfile.mkdtemp(prefix="mltsa-", dir=base_dir))
+    temp_dir = base_dir / f"mltsa-{uuid.uuid4().hex}"
+    temp_dir.mkdir()
     try:
         yield temp_dir
     finally:

--- a/tests/test_explain_models.py
+++ b/tests/test_explain_models.py
@@ -1,0 +1,130 @@
+"""Tests for sklearn wrappers and explainability helpers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from sklearn.datasets import make_classification
+from sklearn.ensemble import RandomForestClassifier
+
+from mltsa.explain import analyze, global_mean_importance, native_importance, permutation_importance
+from mltsa.io.h5 import open_h5, read_utf8_array
+from mltsa.io.schema import results_experiment_path
+from mltsa.models import get_model
+
+
+@pytest.fixture()
+def classification_data() -> tuple[np.ndarray, np.ndarray, tuple[str, ...]]:
+    """Provide a deterministic classification dataset for model tests."""
+
+    X, y = make_classification(
+        n_samples=120,
+        n_features=6,
+        n_informative=4,
+        n_redundant=0,
+        n_repeated=0,
+        n_classes=2,
+        random_state=7,
+    )
+    feature_names = tuple(f"feat_{index}" for index in range(X.shape[1]))
+    return X.astype(np.float64), y.astype(np.int64), feature_names
+
+
+@pytest.mark.parametrize(
+    ("name", "kwargs"),
+    [
+        ("random_forest", {"n_estimators": 20, "random_state": 0}),
+        ("gradient_boosting", {"n_estimators": 20, "random_state": 0}),
+        ("hist_gradient_boosting", {"max_iter": 30, "random_state": 0}),
+        ("extra_trees", {"n_estimators": 20, "random_state": 0}),
+    ],
+)
+def test_model_wrappers_fit_and_predict(name: str, kwargs: dict[str, int], classification_data) -> None:
+    """All supported wrapper models should fit and predict."""
+
+    X, y, _ = classification_data
+    model = get_model(name, **kwargs)
+
+    fitted = model.fit(X, y)
+    predictions = fitted.predict(X)
+
+    assert predictions.shape == y.shape
+    assert set(np.unique(predictions)).issubset({0, 1})
+    assert fitted.score(X, y) > 0.75
+
+
+def test_native_importance_works_without_xy(classification_data) -> None:
+    """Native importance should work for supported models without X or y."""
+
+    X, y, feature_names = classification_data
+    model = get_model("random_forest", n_estimators=40, random_state=0).fit(X, y)
+
+    result = native_importance(model, feature_names=feature_names)
+
+    assert result.method == "native"
+    assert result.feature_names == feature_names
+    assert result.baseline_score is None
+    assert result.importances.shape == (X.shape[1],)
+    assert np.all(result.importances >= 0.0)
+
+
+def test_permutation_and_global_mean_with_external_model(classification_data) -> None:
+    """Permutation and global-mean importance should work with raw sklearn models."""
+
+    X, y, feature_names = classification_data
+    model = RandomForestClassifier(n_estimators=40, random_state=0).fit(X, y)
+
+    permutation = permutation_importance(
+        model,
+        X,
+        y,
+        feature_names=feature_names,
+        n_repeats=5,
+        random_state=0,
+    )
+    global_mean = global_mean_importance(model, X, y, feature_names=feature_names)
+    dispatched = analyze(model, method="permutation", X=X, y=y, feature_names=feature_names, n_repeats=5)
+
+    assert permutation.method == "permutation"
+    assert permutation.feature_names == feature_names
+    assert permutation.baseline_score is not None
+    assert permutation.std is not None
+    assert permutation.perturbed_scores is not None
+    assert permutation.importances.shape == (X.shape[1],)
+
+    assert global_mean.method == "global_mean"
+    assert global_mean.baseline_score is not None
+    assert global_mean.perturbed_scores is not None
+    assert global_mean.importances.shape == (X.shape[1],)
+
+    np.testing.assert_allclose(dispatched.importances, permutation.importances)
+
+
+def test_explanation_results_save_and_append(workspace_tmp_dir, classification_data) -> None:
+    """Explanation results should append cleanly into a results HDF5 file."""
+
+    X, y, feature_names = classification_data
+    model = get_model("extra_trees", n_estimators=30, random_state=0).fit(X, y)
+    native = native_importance(model, feature_names=feature_names)
+    global_mean = global_mean_importance(model, X, y, feature_names=feature_names)
+
+    results_path = workspace_tmp_dir / "explanations.h5"
+    first_path = native.save(results_path, experiment_id="benchmark")
+    second_path = global_mean.save(results_path, experiment_id="benchmark")
+
+    assert first_path.endswith("/explanation_0000")
+    assert second_path.endswith("/explanation_0001")
+
+    with open_h5(results_path, "r") as handle:
+        experiment = handle[f"{results_experiment_path('benchmark')}/explanations"]
+
+        assert tuple(sorted(experiment.keys())) == ("explanation_0000", "explanation_0001")
+        first = experiment["explanation_0000"]
+        second = experiment["explanation_0001"]
+
+        assert first.attrs["method"] == "native"
+        assert second.attrs["method"] == "global_mean"
+        assert "plot_path" not in first.attrs
+        assert read_utf8_array(first, "feature_names") == list(feature_names)
+        np.testing.assert_allclose(first["importances"][...], native.importances)
+        np.testing.assert_allclose(second["score_deltas"][...], global_mean.score_deltas)

--- a/tests/test_md_featurize.py
+++ b/tests/test_md_featurize.py
@@ -1,0 +1,207 @@
+"""Tests for MD featurization and feature-set storage."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mltsa.io.h5 import open_h5, scan_h5
+from mltsa.io.schema import feature_set_path, list_feature_sets
+from mltsa.md import featurize_dataset, label_trajectories, load_dataset
+
+from ._md_fakes import FakeMdtraj, build_fake_md_module, make_xyz, register_fake_inputs
+
+
+@pytest.fixture()
+def fake_md_module() -> FakeMdtraj:
+    """Provide a fake mdtraj module with a reusable topology."""
+
+    return build_fake_md_module()
+
+
+def test_feature_set_creation_and_selected_load(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """Featurization should create one named feature set and load it back cleanly."""
+
+    topology_path, trajectory_paths = register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_a": make_xyz([0.2, 0.3, 0.4, 0.5]),
+            "traj_b": make_xyz([2.0, 2.1, 2.2, 2.3]),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+    monkeypatch.setattr("mltsa.md.featurize._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "md_features.h5"
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_a"], trajectory_paths["traj_b"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=0.8,
+        upper_threshold=1.5,
+        window_size=2,
+        replica_ids=["rep_a", "rep_b"],
+    )
+
+    dataset = featurize_dataset(
+        h5_path=h5_path,
+        feature_set="closest",
+        feature_type="closest_residue_distances",
+        label_experiment_id="labels",
+    )
+
+    assert dataset.feature_set == "closest"
+    assert dataset.feature_type == "closest_residue_distances"
+    assert dataset.replica_ids == ("rep_a", "rep_b")
+    assert dataset.state_labels == ("IN", "OUT")
+    assert dataset.X.shape == (2, 4, 2)
+    assert dataset.feature_names == ("closest_residue:ALA001", "closest_residue:GLY002")
+
+    with open_h5(h5_path, "r") as handle:
+        scan = scan_h5(handle, root=feature_set_path("closest"))
+        assert scan.groups[feature_set_path("closest")].groups == ("replicas",)
+        assert scan.datasets[f"{feature_set_path('closest')}/feature_names"].shape == (2,)
+        assert scan.datasets[f"{feature_set_path('closest')}/replicas/rep_a/X"].shape == (4, 2)
+
+    reloaded = load_dataset(h5_path, "closest")
+    np.testing.assert_allclose(reloaded.X, dataset.X)
+    assert reloaded.feature_names == dataset.feature_names
+
+
+def test_append_skips_existing_and_only_processes_new_replicas(
+    monkeypatch,
+    workspace_tmp_dir: Path,
+    fake_md_module: FakeMdtraj,
+) -> None:
+    """Appending should skip already-featurized replicas before loading trajectory arrays."""
+
+    topology_path, trajectory_paths = register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_a": make_xyz([0.2, 0.3, 0.4, 0.5]),
+            "traj_b": make_xyz([2.0, 2.1, 2.2, 2.3]),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+    monkeypatch.setattr("mltsa.md.featurize._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "append_features.h5"
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_a"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=0.8,
+        upper_threshold=1.5,
+        window_size=2,
+        replica_ids=["rep_a"],
+    )
+    featurize_dataset(
+        h5_path=h5_path,
+        feature_set="closest",
+        feature_type="closest_residue_distances",
+        label_experiment_id="labels",
+    )
+
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_b"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=0.8,
+        upper_threshold=1.5,
+        window_size=2,
+        replica_ids=["rep_b"],
+        append=True,
+    )
+
+    load_calls: list[str] = []
+    original_load = __import__("mltsa.md.featurize", fromlist=["_load_trajectory"])._load_trajectory
+
+    def counting_load(md_module, trajectory_path: Path, topology_path_arg: Path):
+        load_calls.append(Path(trajectory_path).name)
+        return original_load(md_module, trajectory_path, topology_path_arg)
+
+    monkeypatch.setattr("mltsa.md.featurize._load_trajectory", counting_load)
+    result = featurize_dataset(
+        h5_path=h5_path,
+        feature_set="closest",
+        feature_type="closest_residue_distances",
+        label_experiment_id="labels",
+        append=True,
+    )
+
+    assert result.processed_replica_ids == ("rep_b",)
+    assert result.skipped_replica_ids == ("rep_a",)
+    assert load_calls == ["traj_b.dcd"]
+
+
+def test_second_feature_family_in_same_file_and_water_reuse(
+    monkeypatch,
+    workspace_tmp_dir: Path,
+    fake_md_module: FakeMdtraj,
+) -> None:
+    """The same HDF5 should allow a second feature family while reusing stored water metadata."""
+
+    topology_path, trajectory_paths = register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_a": make_xyz([0.2, 0.3, 0.4, 0.5]),
+            "traj_b": make_xyz([0.1, 0.2, 0.3, 0.4], water_near_x=0.35),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+    monkeypatch.setattr("mltsa.md.featurize._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "two_feature_sets.h5"
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_a"], trajectory_paths["traj_b"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=0.8,
+        upper_threshold=1.5,
+        window_size=2,
+        replica_ids=["rep_a", "rep_b"],
+    )
+
+    featurize_dataset(
+        h5_path=h5_path,
+        feature_set="closest",
+        feature_type="closest_residue_distances",
+        label_experiment_id="labels",
+    )
+    bubble_dataset = featurize_dataset(
+        h5_path=h5_path,
+        feature_set="bubble",
+        feature_type="bubble_distances",
+        label_experiment_id="labels",
+        use_waters=True,
+        bubble_cutoff=0.25,
+    )
+
+    assert bubble_dataset.feature_set == "bubble"
+    assert bubble_dataset.X.shape[0] == 2
+    assert any("HOH010" in name or "HOH011" in name for name in bubble_dataset.feature_names)
+
+    with open_h5(h5_path, "r") as handle:
+        assert list_feature_sets(handle) == ("bubble", "closest")
+        assert bool(handle[feature_set_path("bubble")].attrs["use_waters"]) is True
+
+    closest_only = load_dataset(h5_path, "closest")
+    assert closest_only.feature_set == "closest"
+    assert closest_only.feature_type == "closest_residue_distances"

--- a/tests/test_md_label.py
+++ b/tests/test_md_label.py
@@ -1,0 +1,338 @@
+"""Tests for the MD trajectory labeling pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from mltsa.io.h5 import open_h5, read_utf8_array
+from mltsa.io.schema import results_experiment_path
+from mltsa.md import label_trajectories
+
+
+@dataclass(frozen=True, slots=True)
+class FakeElement:
+    symbol: str
+    mass: float
+
+
+@dataclass(frozen=True, slots=True)
+class FakeChain:
+    index: int
+
+
+@dataclass(frozen=True, slots=True)
+class FakeResidue:
+    name: str
+    index: int
+    resSeq: int
+    chain: FakeChain
+    is_water: bool = False
+    is_protein: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class FakeAtom:
+    index: int
+    name: str
+    residue: FakeResidue
+    element: FakeElement
+    serial: int
+
+
+class FakeTopology:
+    """Very small subset of the mdtraj topology interface used by the labeler."""
+
+    def __init__(self, atoms: list[FakeAtom]) -> None:
+        self.atoms = atoms
+
+    def select(self, query: str) -> np.ndarray:
+        normalized = " ".join(query.strip().split()).lower()
+        if normalized.startswith("index "):
+            return np.asarray([int(normalized.split()[1])], dtype=np.int64)
+        if normalized == "protein":
+            return np.asarray([atom.index for atom in self.atoms if atom.residue.is_protein], dtype=np.int64)
+        if normalized == "resname lig":
+            return np.asarray([atom.index for atom in self.atoms if atom.residue.name.upper() == "LIG"], dtype=np.int64)
+        if normalized in {"water", "resname hoh", "water and name o", "name o and water"}:
+            return np.asarray(
+                [
+                    atom.index
+                    for atom in self.atoms
+                    if atom.residue.is_water and (normalized in {"water", "resname hoh"} or atom.name.upper().startswith("O"))
+                ],
+                dtype=np.int64,
+            )
+        raise KeyError(f"Unsupported fake selection: {query!r}")
+
+
+class FakeTrajectory:
+    """Small trajectory container with the attributes needed by the labeler."""
+
+    def __init__(self, xyz: np.ndarray, topology: FakeTopology) -> None:
+        self.xyz = np.asarray(xyz, dtype=np.float64)
+        self.topology = topology
+        self.top = topology
+
+
+class FakeMdtraj:
+    """Registry-backed fake mdtraj module used for tests."""
+
+    def __init__(self) -> None:
+        self._registry: dict[str, FakeTrajectory] = {}
+
+    def register(self, path: Path, trajectory: FakeTrajectory) -> None:
+        self._registry[path.resolve().as_posix().casefold()] = trajectory
+
+    def load(self, path: str, top: str | None = None) -> FakeTrajectory:
+        key = Path(path).resolve().as_posix().casefold()
+        trajectory = self._registry[key]
+        if top is None:
+            return trajectory
+        topology_key = Path(top).resolve().as_posix().casefold()
+        topology = self._registry[topology_key].topology
+        return FakeTrajectory(np.asarray(trajectory.xyz, dtype=np.float64), topology)
+
+
+@pytest.fixture()
+def fake_md_module() -> FakeMdtraj:
+    """Provide a fake mdtraj module with a reusable topology."""
+
+    chain = FakeChain(index=0)
+    residues = [
+        FakeResidue(name="ALA", index=0, resSeq=1, chain=chain, is_protein=True),
+        FakeResidue(name="ALA", index=0, resSeq=1, chain=chain, is_protein=True),
+        FakeResidue(name="LIG", index=1, resSeq=2, chain=chain),
+        FakeResidue(name="HOH", index=2, resSeq=10, chain=chain, is_water=True),
+        FakeResidue(name="HOH", index=3, resSeq=11, chain=chain, is_water=True),
+    ]
+    atoms = [
+        FakeAtom(index=0, name="CA", residue=residues[0], element=FakeElement("C", 12.0), serial=1),
+        FakeAtom(index=1, name="CB", residue=residues[1], element=FakeElement("C", 12.0), serial=2),
+        FakeAtom(index=2, name="C1", residue=residues[2], element=FakeElement("C", 12.0), serial=3),
+        FakeAtom(index=3, name="O", residue=residues[3], element=FakeElement("O", 16.0), serial=4),
+        FakeAtom(index=4, name="O", residue=residues[4], element=FakeElement("O", 16.0), serial=5),
+    ]
+    topology = FakeTopology(atoms)
+    topology_traj = FakeTrajectory(np.zeros((1, len(atoms), 3), dtype=np.float64), topology)
+
+    fake_md = FakeMdtraj()
+    fake_md.topology = topology_traj
+    return fake_md
+
+
+def _make_xyz(ligand_x: list[float], *, water_near_x: float = 0.7, water_far_x: float = 8.0) -> np.ndarray:
+    """Build a tiny deterministic trajectory geometry."""
+
+    xyz = np.zeros((len(ligand_x), 5, 3), dtype=np.float64)
+    xyz[:, 0, :] = np.array([0.0, 0.0, 0.0], dtype=np.float64)
+    xyz[:, 1, :] = np.array([1.0, 0.0, 0.0], dtype=np.float64)
+    xyz[:, 2, 0] = np.asarray(ligand_x, dtype=np.float64)
+    xyz[:, 3, 0] = water_near_x
+    xyz[:, 4, 0] = water_far_x
+    return xyz
+
+
+def _register_fake_inputs(workspace_tmp_dir: Path, fake_md_module: FakeMdtraj, names_to_xyz: dict[str, np.ndarray]) -> tuple[Path, dict[str, Path]]:
+    """Register topology and trajectory paths in the fake mdtraj registry."""
+
+    topology_path = workspace_tmp_dir / "topology.pdb"
+    topology_path.write_text("fake topology\n", encoding="utf-8")
+    fake_md_module.register(topology_path, fake_md_module.topology)
+
+    trajectory_paths: dict[str, Path] = {}
+    for name, xyz in names_to_xyz.items():
+        path = workspace_tmp_dir / f"{name}.dcd"
+        path.write_text("fake trajectory\n", encoding="utf-8")
+        fake_md_module.register(path, FakeTrajectory(xyz, fake_md_module.topology.topology))
+        trajectory_paths[name] = path
+    return topology_path, trajectory_paths
+
+
+def test_final_window_logic_and_water_storage(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """Labeling should depend only on the final fixed frame window and store water metadata by default."""
+
+    topology_path, trajectory_paths = _register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {"traj_window": _make_xyz([8.0, 8.0, 8.0, 0.5, 0.5])},
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+
+    result = label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_window"]],
+        topology=topology_path,
+        h5_path=workspace_tmp_dir / "labels.h5",
+        experiment_id="md_labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2"), ("index 1", "index 2")],
+        lower_threshold=2.0,
+        upper_threshold=5.0,
+        window_size=2,
+    )
+
+    assert len(result.processed) == 1
+    entry = result.processed[0]
+    assert entry.label == "IN"
+    assert entry.final_window_start == 3
+    np.testing.assert_allclose(entry.frame_values, np.array([1.0, 1.0]))
+    assert entry.nearby_waters is not None
+    assert entry.nearby_waters.residue_ids[0] == 10
+    assert result.state_counts == {"IN": 1, "OUT": 0, "TS": 0}
+
+    with open_h5(workspace_tmp_dir / "labels.h5", "r") as handle:
+        store = handle[f"{results_experiment_path('md_labels')}/trajectory_labels"]
+        entries = store["entries"]
+        stored_entry = entries[entry.entry_key]
+        waters = stored_entry["nearby_waters"]
+
+        assert bool(stored_entry.attrs["waters_stored"]) is True
+        assert read_utf8_array(stored_entry, "component_labels") == ["index 0 -> index 2", "index 1 -> index 2"]
+        np.testing.assert_allclose(stored_entry["frame_values"][...], np.array([1.0, 1.0]))
+        np.testing.assert_allclose(waters["mean_distances"][...], entry.nearby_waters.mean_distances)
+
+    summary = json.loads(result.summary_path.read_text(encoding="utf-8"))
+    assert summary["state_counts"] == {"IN": 1, "OUT": 0, "TS": 0}
+    assert result.pie_chart_path.exists()
+
+
+def test_append_uses_normalized_paths_and_skips_existing(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """Appending should identify existing entries from normalized paths plus replica ids."""
+
+    topology_path, trajectory_paths = _register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_same": _make_xyz([8.0, 8.0, 8.0, 0.5, 0.5]),
+            "traj_new": _make_xyz([8.0, 8.0, 8.0, 7.5, 7.5]),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "append_labels.h5"
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_same"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="append_case",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=1.0,
+        upper_threshold=5.0,
+        window_size=2,
+        replica_ids=["replica_a"],
+    )
+
+    relative_same = trajectory_paths["traj_same"].relative_to(Path.cwd())
+    result = label_trajectories(
+        trajectory_paths=[relative_same, trajectory_paths["traj_new"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="append_case",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=1.0,
+        upper_threshold=5.0,
+        window_size=2,
+        replica_ids=["replica_a", "replica_b"],
+        append=True,
+    )
+
+    assert len(result.processed) == 1
+    assert len(result.skipped_entry_keys) == 1
+    assert result.state_counts == {"IN": 1, "OUT": 1, "TS": 0}
+
+    with open_h5(h5_path, "r") as handle:
+        entries = handle[f"{results_experiment_path('append_case')}/trajectory_labels/entries"]
+        assert len(entries.keys()) == 2
+
+
+def test_overwrite_relabels_existing_entry(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """overwrite=True should replace an existing entry instead of silently skipping it."""
+
+    topology_path, trajectory_paths = _register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {"traj_replace": _make_xyz([8.0, 8.0, 8.0, 0.5, 0.5])},
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "overwrite_labels.h5"
+    label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_replace"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="overwrite_case",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=1.0,
+        upper_threshold=5.0,
+        window_size=2,
+        replica_ids=["replica_x"],
+    )
+
+    fake_md_module.register(trajectory_paths["traj_replace"], FakeTrajectory(_make_xyz([8.0, 8.0, 8.0, 7.5, 7.5]), fake_md_module.topology.topology))
+    result = label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_replace"]],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="overwrite_case",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=1.0,
+        upper_threshold=5.0,
+        window_size=2,
+        replica_ids=["replica_x"],
+        append=True,
+        overwrite=True,
+    )
+
+    assert len(result.processed) == 1
+    assert len(result.overwritten_entry_keys) == 1
+    assert result.processed[0].label == "OUT"
+
+    with open_h5(h5_path, "r") as handle:
+        entry = next(iter(handle[f"{results_experiment_path('overwrite_case')}/trajectory_labels/entries"].values()))
+        assert entry.attrs["state_label"] == "OUT"
+
+
+def test_com_distance_rule_and_snapshot_export_do_not_crash(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """COM-distance labeling and optional snapshot export should work on a tiny mocked case."""
+
+    topology_path, trajectory_paths = _register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_in": _make_xyz([8.0, 8.0, 8.0, 0.2, 0.2]),
+            "traj_ts": _make_xyz([8.0, 8.0, 8.0, 3.0, 3.0]),
+            "traj_out": _make_xyz([8.0, 8.0, 8.0, 7.5, 7.5]),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+
+    result = label_trajectories(
+        trajectory_paths=[trajectory_paths["traj_in"], trajectory_paths["traj_ts"], trajectory_paths["traj_out"]],
+        topology=topology_path,
+        h5_path=workspace_tmp_dir / "snapshot_labels.h5",
+        experiment_id="snapshot_case",
+        rule="com_distance",
+        selection_pairs=[("protein", "resname LIG")],
+        lower_threshold=1.0,
+        upper_threshold=5.0,
+        window_size=2,
+        replica_ids=["rep_in", "rep_ts", "rep_out"],
+        export_snapshots=True,
+        snapshot_dir=workspace_tmp_dir / "snapshots",
+        center_snapshots=True,
+        align_protein=True,
+    )
+
+    assert result.state_counts == {"IN": 1, "OUT": 1, "TS": 1}
+    for state in ("IN", "OUT", "TS"):
+        path = result.snapshot_paths[state]
+        assert path.exists()
+        assert "MODEL" in path.read_text(encoding="utf-8")

--- a/tests/test_torch_models.py
+++ b/tests/test_torch_models.py
@@ -1,0 +1,58 @@
+"""Tests for the lightweight PyTorch model wrappers."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from mltsa.models import CNN1D, LSTM, MLP, get_model
+
+
+@pytest.fixture()
+def tiny_sequence_data() -> tuple[np.ndarray, np.ndarray]:
+    """Provide a tiny deterministic binary time-series dataset."""
+
+    rng = np.random.default_rng(42)
+    X = rng.normal(size=(24, 5, 3)).astype(np.float32)
+    signal = X[:, :, 0].mean(axis=1) + 0.5 * X[:, -1, 1]
+    y = (signal > 0.0).astype(np.int64)
+    return X, y
+
+
+@pytest.mark.parametrize(
+    ("factory_name", "kwargs", "wrapper_type"),
+    [
+        ("mlp", {"hidden_sizes": (16,), "epochs": 4, "batch_size": 8, "learning_rate": 0.01}, MLP),
+        ("lstm", {"hidden_size": 12, "epochs": 4, "batch_size": 8, "learning_rate": 0.01}, LSTM),
+        ("cnn1d", {"channels": 8, "epochs": 4, "batch_size": 8, "learning_rate": 0.01}, CNN1D),
+    ],
+)
+def test_torch_wrappers_fit_predict_and_save_load(
+    workspace_tmp_dir,
+    tiny_sequence_data,
+    factory_name: str,
+    kwargs: dict[str, object],
+    wrapper_type: type[MLP | LSTM | CNN1D],
+) -> None:
+    """Torch wrappers should fit, predict, and reload on tiny data."""
+
+    X, y = tiny_sequence_data
+    model = get_model(factory_name, random_state=0, **kwargs)
+
+    assert isinstance(model, wrapper_type)
+
+    fitted = model.fit(X, y)
+    predictions = fitted.predict(X)
+    probabilities = fitted.predict_proba(X)
+
+    assert predictions.shape == y.shape
+    assert probabilities.shape == (X.shape[0], 2)
+    np.testing.assert_allclose(probabilities.sum(axis=1), np.ones(X.shape[0]), atol=1e-5)
+
+    save_path = workspace_tmp_dir / f"{factory_name}.pt"
+    fitted.save(save_path)
+    reloaded = wrapper_type.load(save_path)
+    reloaded_probabilities = reloaded.predict_proba(X)
+
+    assert reloaded.predict(X).shape == y.shape
+    np.testing.assert_allclose(reloaded_probabilities.sum(axis=1), np.ones(X.shape[0]), atol=1e-5)


### PR DESCRIPTION
## Summary

This PR adds the first MD-specific workflow layer for the new `mltsa` package.

It introduces:
- a robust trajectory labeling pipeline based on the final window of each trajectory
- append-safe HDF5 storage for labels and MD feature sets
- reusable MD featurization with multiple feature families in the same dataset file
- support for reusing stored nearby-water metadata during featurization

## Changes

- add MD trajectory labeling with `label_trajectories(...)`
- support v1 labeling rules:
  - `sum_distances`
  - `com_distance`
- fix the old labeling flaw by using only the last `window_size` frames
- classify trajectories as `IN`, `OUT`, or `TS` from the mean rule value over the final window
- store labeling results in HDF5 with append and overwrite behavior keyed by normalized trajectory path plus replica id
- store nearby-water metadata by default
- support optional snapshot export to multi-model `IN.pdb`, `OUT.pdb`, and `TS.pdb`
- generate a JSON summary and state-count pie chart

- add MD featurization with:
  - `featurize_dataset(...)`
  - `load_dataset(...)`
  - `MDFeatureDataset`
- support v1 feature families:
  - `closest_residue_distances`
  - `all_ligand_protein_distances`
  - `bubble_distances`
  - `contact_map`
  - `pca_xyz`
- store feature sets under `/md/feature_sets/<name>`
- allow multiple feature sets in the same HDF5 file
- allow loading only one selected feature set
- support append mode that scans metadata and skips already completed replicas without loading full stored arrays
- support explicit reuse of stored water metadata when `use_waters=True`

## Testing

Added focused tests for:
- final-window labeling logic
- append and overwrite labeling behavior
- water metadata storage
- snapshot export on a tiny mocked case
- feature-set creation
- appending new replicas
- adding a second feature family to the same file
- loading a single selected feature set
- lightweight scanning behavior

Test command:
- `C:\Users\pedro\projects\GAP\.conda\python.exe -m pytest`

Result:
- `28 passed`

## Notes

- real `mdtraj` is still imported lazily at runtime
- tests use a mocked mdtraj shim in this Windows environment because binary installation was not available here
- this PR adds the reusable MD data layer only; it does not yet implement downstream MD model-training workflows
