### PR TITLE
refactor command line add MD analysis workflow with CLI commands

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ md = [
 
 [project.scripts]
 mltsa = "mltsa.cli:main"
+mltsa-md = "mltsa.cli.md:main"
 
 [project.urls]
 Documentation = "https://mltsa.readthedocs.io/en/latest/"

--- a/src/mltsa/cli/main.py
+++ b/src/mltsa/cli/main.py
@@ -1,4 +1,4 @@
-"""Minimal CLI entry point for the mltsa package."""
+"""CLI entry point for the mltsa package."""
 
 from __future__ import annotations
 
@@ -7,6 +7,8 @@ from collections.abc import Sequence
 
 from mltsa import __version__
 
+from . import md as md_cli
+
 
 def build_parser() -> ArgumentParser:
     """Create the root argument parser for the project CLI."""
@@ -14,7 +16,7 @@ def build_parser() -> ArgumentParser:
         prog="mltsa",
         description=(
             "Machine Learning Transition State Analysis toolkit. "
-            "Scientific subcommands will arrive in future milestones."
+            "Use `mltsa md ...` or the dedicated `mltsa-md` command for MD workflows."
         ),
     )
     parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
@@ -23,7 +25,11 @@ def build_parser() -> ArgumentParser:
 
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the CLI and return a process exit code."""
+    arguments = list(argv) if argv is not None else None
+    if arguments and arguments[0] == "md":
+        return int(md_cli.main(arguments[1:]))
+
     parser = build_parser()
-    parser.parse_args(list(argv) if argv is not None else None)
+    parser.parse_args(arguments)
     parser.print_help()
     return 0

--- a/src/mltsa/cli/md.py
+++ b/src/mltsa/cli/md.py
@@ -1,0 +1,216 @@
+"""Thin command-line wrapper for MD workflows."""
+
+from __future__ import annotations
+
+import json
+from argparse import ArgumentParser, Namespace
+from collections.abc import Sequence
+from pathlib import Path
+
+from mltsa import __version__
+from mltsa.md import featurize_dataset, label_trajectories, run_mltsa
+
+
+def build_parser() -> ArgumentParser:
+    """Create the ``mltsa-md`` argument parser."""
+
+    parser = ArgumentParser(
+        prog="mltsa-md",
+        description="Label, featurize, and analyze MD datasets stored in mltsa HDF5 files.",
+    )
+    parser.add_argument("--version", action="version", version=f"%(prog)s {__version__}")
+    subparsers = parser.add_subparsers(dest="command")
+
+    label_parser = subparsers.add_parser("label", help="Label trajectories into IN/OUT/TS states.")
+    label_parser.add_argument("--h5", required=True, help="Target HDF5 path for the stored labels.")
+    label_parser.add_argument("--experiment", required=True, help="Results experiment id used for labeling output.")
+    label_parser.add_argument("--topology", required=True, help="Topology file shared by the trajectories.")
+    label_parser.add_argument("--trajectory", action="append", required=True, help="Trajectory path. Repeat for multiple inputs.")
+    label_parser.add_argument("--replica-id", action="append", default=None, help="Replica identifier. Repeat in trajectory order.")
+    label_parser.add_argument("--rule", choices=("sum_distances", "com_distance"), required=True)
+    label_parser.add_argument(
+        "--selection-pair",
+        action="append",
+        nargs=2,
+        metavar=("LEFT", "RIGHT"),
+        required=True,
+        help="Selection pair used by the labeling rule. Repeat as needed.",
+    )
+    label_parser.add_argument("--lower-threshold", type=float, required=True)
+    label_parser.add_argument("--upper-threshold", type=float, required=True)
+    label_parser.add_argument("--window-size", type=int, required=True)
+    label_parser.add_argument("--append", action="store_true", help="Append new entries instead of requiring an empty store.")
+    label_parser.add_argument("--overwrite", action="store_true", help="Overwrite matching entries or stores when allowed.")
+    label_parser.add_argument("--no-waters", action="store_true", help="Disable nearby-water metadata capture.")
+    label_parser.add_argument("--n-waters", type=int, default=50, help="Number of nearby waters to store when enabled.")
+    label_parser.add_argument("--export-snapshots", action="store_true", help="Write IN/OUT/TS multi-model PDB snapshots.")
+    label_parser.add_argument("--snapshot-dir", default=None, help="Output directory for snapshot PDB files.")
+    label_parser.add_argument("--center-snapshots", action="store_true")
+    label_parser.add_argument("--align-protein", action="store_true")
+    label_parser.set_defaults(handler=_handle_label)
+
+    build_parser_ = subparsers.add_parser("build", help="Build one named feature set inside an MD HDF5 dataset.")
+    build_parser_.add_argument("--h5", required=True, help="MD dataset HDF5 path.")
+    build_parser_.add_argument("--feature-set", required=True, help="Name of the feature set to create or append.")
+    build_parser_.add_argument(
+        "--feature-type",
+        required=True,
+        choices=(
+            "closest_residue_distances",
+            "all_ligand_protein_distances",
+            "bubble_distances",
+            "contact_map",
+            "pca_xyz",
+        ),
+    )
+    build_parser_.add_argument("--label-experiment", required=True, help="Label experiment id used as the source labels.")
+    build_parser_.add_argument("--replica-id", action="append", default=None, help="Replica identifier to featurize. Repeat as needed.")
+    build_parser_.add_argument("--append", action="store_true")
+    build_parser_.add_argument("--overwrite", action="store_true")
+    build_parser_.add_argument("--use-waters", action="store_true", help="Reuse stored nearby-water metadata when available.")
+    build_parser_.add_argument("--ligand-selection", default="resname LIG")
+    build_parser_.add_argument("--protein-selection", default="protein")
+    build_parser_.add_argument("--bubble-cutoff", type=float, default=0.6)
+    build_parser_.add_argument("--contact-threshold", type=float, default=0.45)
+    build_parser_.add_argument("--pca-components", type=int, default=3)
+    build_parser_.add_argument("--pca-selection", default=None)
+    build_parser_.set_defaults(handler=_handle_build)
+
+    analyze_parser = subparsers.add_parser("analyze", help="Train a model and compute feature importances for one feature set.")
+    analyze_parser.add_argument("--h5", required=True, help="MD dataset HDF5 path.")
+    analyze_parser.add_argument("--feature-set", required=True, help="Feature set name to analyze.")
+    analyze_parser.add_argument("--model", default="random_forest", help="Model name understood by mltsa.models.get_model(...).")
+    analyze_parser.add_argument("--model-kwarg", action="append", default=None, help="Model parameter as KEY=VALUE. Repeat as needed.")
+    analyze_parser.add_argument("--explain", default="native", help="Explainability method to use.")
+    analyze_parser.add_argument("--explain-kwarg", action="append", default=None, help="Explain parameter as KEY=VALUE. Repeat as needed.")
+    analyze_parser.add_argument("--results-h5", default=None, help="Optional results HDF5 path for persisted analysis output.")
+    analyze_parser.add_argument("--experiment", default=None, help="Optional results experiment id.")
+    analyze_parser.set_defaults(handler=_handle_analyze)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the ``mltsa-md`` CLI and return a process exit code."""
+
+    parser = build_parser()
+    namespace = parser.parse_args(list(argv) if argv is not None else None)
+    handler = getattr(namespace, "handler", None)
+    if handler is None:
+        parser.print_help()
+        return 0
+    return int(handler(namespace))
+
+
+def _handle_label(namespace: Namespace) -> int:
+    """Dispatch the ``label`` subcommand to the Python API."""
+
+    result = label_trajectories(
+        trajectory_paths=[Path(path) for path in namespace.trajectory],
+        topology=Path(namespace.topology),
+        h5_path=Path(namespace.h5),
+        experiment_id=namespace.experiment,
+        rule=namespace.rule,
+        selection_pairs=[(str(left), str(right)) for left, right in namespace.selection_pair],
+        lower_threshold=float(namespace.lower_threshold),
+        upper_threshold=float(namespace.upper_threshold),
+        window_size=int(namespace.window_size),
+        replica_ids=None if namespace.replica_id is None else list(namespace.replica_id),
+        append=bool(namespace.append),
+        overwrite=bool(namespace.overwrite),
+        store_waters=not bool(namespace.no_waters),
+        n_waters=int(namespace.n_waters),
+        export_snapshots=bool(namespace.export_snapshots),
+        snapshot_dir=None if namespace.snapshot_dir is None else Path(namespace.snapshot_dir),
+        center_snapshots=bool(namespace.center_snapshots),
+        align_protein=bool(namespace.align_protein),
+    )
+    print(
+        f"Labeled {len(result.processed)} trajectories "
+        f"(skipped={len(result.skipped_entry_keys)}, overwritten={len(result.overwritten_entry_keys)})."
+    )
+    return 0
+
+
+def _handle_build(namespace: Namespace) -> int:
+    """Dispatch the ``build`` subcommand to the Python API."""
+
+    dataset = featurize_dataset(
+        h5_path=Path(namespace.h5),
+        feature_set=namespace.feature_set,
+        feature_type=namespace.feature_type,
+        label_experiment_id=namespace.label_experiment,
+        replica_ids=None if namespace.replica_id is None else list(namespace.replica_id),
+        append=bool(namespace.append),
+        overwrite=bool(namespace.overwrite),
+        use_waters=bool(namespace.use_waters),
+        ligand_selection=namespace.ligand_selection,
+        protein_selection=namespace.protein_selection,
+        bubble_cutoff=float(namespace.bubble_cutoff),
+        contact_threshold=float(namespace.contact_threshold),
+        pca_components=int(namespace.pca_components),
+        pca_selection=namespace.pca_selection,
+    )
+    print(
+        f"Feature set {dataset.feature_set!r}: "
+        f"{dataset.n_replicas} replicas, {dataset.n_frames} frames, {dataset.n_features} features."
+    )
+    return 0
+
+
+def _handle_analyze(namespace: Namespace) -> int:
+    """Dispatch the ``analyze`` subcommand to the Python API."""
+
+    model_kwargs = _parse_key_value_options(namespace.model_kwarg)
+    explanation_kwargs = _parse_key_value_options(namespace.explain_kwarg)
+    result = run_mltsa(
+        Path(namespace.h5),
+        namespace.feature_set,
+        model=namespace.model,
+        model_kwargs=model_kwargs,
+        explanation_method=namespace.explain,
+        explanation_kwargs=explanation_kwargs,
+        results_h5_path=None if namespace.results_h5 is None else Path(namespace.results_h5),
+        experiment_id=namespace.experiment,
+    )
+    print(
+        f"Analysis complete with {result.model_name}: "
+        f"score={result.training_score:.3f}, features={result.explanation.n_features}."
+    )
+    return 0
+
+
+def _parse_key_value_options(values: Sequence[str] | None) -> dict[str, object]:
+    """Parse repeated ``KEY=VALUE`` options with JSON-like value coercion."""
+
+    parsed: dict[str, object] = {}
+    for item in values or ():
+        if "=" not in item:
+            raise ValueError(f"Expected KEY=VALUE, received {item!r}.")
+        key, raw_value = item.split("=", 1)
+        key = key.strip()
+        if not key:
+            raise ValueError("Option keys must not be empty.")
+        parsed[key] = _coerce_cli_value(raw_value.strip())
+    return parsed
+
+
+def _coerce_cli_value(value: str) -> object:
+    """Best-effort coercion for CLI keyword values."""
+
+    if value == "":
+        return ""
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        lowered = value.lower()
+        if lowered == "true":
+            return True
+        if lowered == "false":
+            return False
+        if lowered == "none":
+            return None
+        return value
+
+
+__all__ = ["build_parser", "main"]

--- a/src/mltsa/md/__init__.py
+++ b/src/mltsa/md/__init__.py
@@ -1,13 +1,20 @@
 """Molecular dynamics specific workflows for mltsa."""
 
+from .analyze import MDAnalysisResult, plot_feature_traces, plot_top_features, run_mltsa
+from .export import export_state_structures
 from .featurize import MDFeatureDataset, featurize_dataset, load_dataset
 from .label import LabelingResult, TrajectoryLabelEntry, label_trajectories
 
 __all__ = [
+    "MDAnalysisResult",
     "LabelingResult",
     "MDFeatureDataset",
     "TrajectoryLabelEntry",
+    "export_state_structures",
     "featurize_dataset",
     "label_trajectories",
     "load_dataset",
+    "plot_feature_traces",
+    "plot_top_features",
+    "run_mltsa",
 ]

--- a/src/mltsa/md/analyze.py
+++ b/src/mltsa/md/analyze.py
@@ -1,0 +1,260 @@
+"""High-level MD analysis workflow built on stored MD feature sets."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import h5py
+import numpy as np
+
+from mltsa.explain import ExplanationResult, analyze as analyze_explanation, plot_importances
+from mltsa.io.h5 import create_appendable_group, ensure_group, open_h5, replace_dataset, write_utf8_array
+from mltsa.io.schema import ensure_results_layout, results_experiment_path
+from mltsa.models import get_model
+from mltsa.synthetic.base import JSONValue
+
+from .featurize import MDFeatureDataset, load_dataset
+
+
+@dataclass(slots=True)
+class MDAnalysisResult:
+    """Result bundle produced by :func:`run_mltsa`."""
+
+    dataset: MDFeatureDataset
+    X: np.ndarray
+    y: np.ndarray
+    analysis_feature_names: tuple[str, ...]
+    model: object
+    model_name: str
+    predictions: np.ndarray
+    probabilities: np.ndarray | None
+    training_score: float
+    explanation: ExplanationResult
+    metadata: dict[str, JSONValue] = field(default_factory=dict)
+    results_h5_path: Path | None = None
+    analysis_path: str | None = None
+    explanation_path: str | None = None
+
+    def save(self, path: str | Path, *, experiment_id: str = "md_analysis") -> tuple[str, str]:
+        """Append analysis outputs to a results HDF5 file."""
+
+        results_path = Path(path)
+        with open_h5(results_path, "a") as handle:
+            ensure_results_layout(handle)
+            experiment = ensure_group(handle, results_experiment_path(experiment_id), attrs={"workflow": "md_analysis"})
+            analysis_group = create_appendable_group(experiment, "analyses", prefix="analysis", width=4)
+            analysis_group.attrs["model_name"] = self.model_name
+            analysis_group.attrs["feature_set"] = self.dataset.feature_set
+            analysis_group.attrs["feature_type"] = self.dataset.feature_type
+            analysis_group.attrs["metadata_json"] = json.dumps(self.metadata, sort_keys=True)
+            analysis_group.attrs["training_score"] = float(self.training_score)
+            analysis_group.attrs["n_samples"] = int(self.X.shape[0])
+            analysis_group.attrs["n_features"] = int(self.X.shape[1])
+
+            replace_dataset(analysis_group, "y_true", np.asarray(self.y))
+            replace_dataset(analysis_group, "y_pred", np.asarray(self.predictions))
+            write_utf8_array(analysis_group, "replica_ids", self.dataset.replica_ids, overwrite=True)
+            write_utf8_array(analysis_group, "state_labels", self.dataset.state_labels, overwrite=True)
+            write_utf8_array(analysis_group, "feature_names", self.analysis_feature_names, overwrite=True)
+            if self.probabilities is not None:
+                replace_dataset(analysis_group, "predict_proba", np.asarray(self.probabilities, dtype=np.float64))
+
+            analysis_path = analysis_group.name
+
+        explanation_path = self.explanation.save(results_path, experiment_id=experiment_id)
+        self.results_h5_path = results_path
+        self.analysis_path = analysis_path
+        self.explanation_path = explanation_path
+        return analysis_path, explanation_path
+
+
+def run_mltsa(
+    dataset_h5_path: str | Path,
+    feature_set: str,
+    *,
+    model: object | str | None = None,
+    model_kwargs: Mapping[str, object] | None = None,
+    explanation_method: str = "native",
+    explanation_kwargs: Mapping[str, object] | None = None,
+    results_h5_path: str | Path | None = None,
+    experiment_id: str | None = None,
+) -> MDAnalysisResult:
+    """Load one MD feature set, train a model, and compute feature importance."""
+
+    dataset = load_dataset(dataset_h5_path, feature_set)
+    matrix, flattened_feature_names = _flatten_dataset(dataset)
+    estimator = _resolve_model(model, model_kwargs=model_kwargs)
+    estimator.fit(matrix, dataset.y)
+    predictions = np.asarray(estimator.predict(matrix))
+
+    probabilities: np.ndarray | None
+    try:
+        probabilities = np.asarray(estimator.predict_proba(matrix), dtype=np.float64)
+    except (AttributeError, NotImplementedError):
+        probabilities = None
+
+    if hasattr(estimator, "score"):
+        training_score = float(estimator.score(matrix, dataset.y))
+    else:
+        training_score = float(np.mean(predictions == dataset.y))
+
+    explanation = analyze_explanation(
+        estimator,
+        method=explanation_method,
+        X=matrix,
+        y=dataset.y,
+        feature_names=flattened_feature_names,
+        **dict(explanation_kwargs or {}),
+    )
+
+    model_name = getattr(estimator, "model_name", type(estimator).__name__)
+    result = MDAnalysisResult(
+        dataset=dataset,
+        X=matrix,
+        y=np.asarray(dataset.y),
+        analysis_feature_names=flattened_feature_names,
+        model=estimator,
+        model_name=str(model_name),
+        predictions=predictions,
+        probabilities=probabilities,
+        training_score=training_score,
+        explanation=explanation,
+        metadata={
+            "dataset_h5_path": str(Path(dataset_h5_path)),
+            "feature_set": dataset.feature_set,
+            "feature_type": dataset.feature_type,
+            "explanation_method": explanation.method,
+        },
+    )
+
+    if results_h5_path is not None:
+        resolved_experiment_id = experiment_id or _default_experiment_id(
+            feature_set=dataset.feature_set,
+            model_name=str(model_name),
+            explanation_method=explanation.method,
+        )
+        result.save(results_h5_path, experiment_id=resolved_experiment_id)
+
+    return result
+
+
+def plot_top_features(
+    result: MDAnalysisResult | ExplanationResult,
+    *,
+    top_n: int = 10,
+    ax: Any | None = None,
+) -> Any:
+    """Plot the most important features from an MD analysis result."""
+
+    explanation = result.explanation if isinstance(result, MDAnalysisResult) else result
+    return plot_importances(explanation, top_n=top_n, ax=ax)
+
+
+def plot_feature_traces(
+    result: MDAnalysisResult | MDFeatureDataset,
+    *,
+    feature_indices: list[int] | tuple[int, ...] | None = None,
+    top_n: int = 3,
+    ax: Any | None = None,
+) -> Any:
+    """Plot mean feature traces by state for selected base MD features."""
+
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as exc:
+        raise RuntimeError("matplotlib is required for MD plotting helpers.") from exc
+
+    dataset = result.dataset if isinstance(result, MDAnalysisResult) else result
+    selected = _select_trace_features(result, dataset=dataset, feature_indices=feature_indices, top_n=top_n)
+    if not selected:
+        raise ValueError("No feature indices were selected for plotting.")
+
+    axes: list[Any]
+    if ax is None:
+        figure, created_axes = plt.subplots(len(selected), 1, figsize=(7, 3 * len(selected)), squeeze=False)
+        axes = created_axes[:, 0].tolist()
+        figure.tight_layout()
+    else:
+        axes = [ax]
+        if len(selected) > 1:
+            raise ValueError("A single Axes object can only be used for one feature trace.")
+
+    x_values = np.arange(dataset.n_frames)
+    state_colors = {"IN": "#4c956c", "OUT": "#bc4749", "TS": "#f4a259"}
+
+    for axis, feature_index in zip(axes, selected):
+        for state_label in ("IN", "OUT", "TS"):
+            mask = np.asarray([label == state_label for label in dataset.state_labels], dtype=bool)
+            if not mask.any():
+                continue
+            mean_trace = dataset.X[mask, :, feature_index].mean(axis=0)
+            axis.plot(x_values, mean_trace, label=state_label, color=state_colors[state_label])
+        axis.set_title(dataset.feature_names[feature_index])
+        axis.set_xlabel("frame")
+        axis.set_ylabel("feature value")
+        axis.legend()
+
+    return axes if len(axes) > 1 else axes[0]
+
+
+def _flatten_dataset(dataset: MDFeatureDataset) -> tuple[np.ndarray, tuple[str, ...]]:
+    """Flatten one MD feature set into a 2D matrix suitable for model fitting."""
+
+    matrix = np.asarray(dataset.X, dtype=np.float64).reshape(dataset.n_replicas, dataset.n_frames * dataset.n_features)
+    feature_names = tuple(
+        f"{name}@t{frame_index:03d}"
+        for frame_index in range(dataset.n_frames)
+        for name in dataset.feature_names
+    )
+    return matrix, feature_names
+
+
+def _resolve_model(model: object | str | None, *, model_kwargs: Mapping[str, object] | None) -> object:
+    """Resolve a user-provided model object or a named mltsa model."""
+
+    kwargs = dict(model_kwargs or {})
+    if model is None:
+        return get_model("random_forest", **kwargs)
+    if isinstance(model, str):
+        return get_model(model, **kwargs)
+    if kwargs:
+        raise ValueError("model_kwargs can only be used when model is provided by name or omitted.")
+    return model
+
+
+def _select_trace_features(
+    result: MDAnalysisResult | MDFeatureDataset,
+    *,
+    dataset: MDFeatureDataset,
+    feature_indices: list[int] | tuple[int, ...] | None,
+    top_n: int,
+) -> list[int]:
+    """Resolve which base feature traces should be plotted."""
+
+    if feature_indices is not None:
+        return [int(index) for index in feature_indices]
+
+    if isinstance(result, MDAnalysisResult):
+        importances = np.asarray(result.explanation.importances, dtype=np.float64)
+        if importances.size == dataset.n_frames * dataset.n_features:
+            aggregated = importances.reshape(dataset.n_frames, dataset.n_features).mean(axis=0)
+            return np.argsort(aggregated)[::-1][:top_n].astype(int).tolist()
+
+    return list(range(min(top_n, dataset.n_features)))
+
+
+def _default_experiment_id(*, feature_set: str, model_name: str, explanation_method: str) -> str:
+    """Build a stable default experiment identifier for saved results."""
+
+    parts = [feature_set, model_name, explanation_method]
+    return "_".join(
+        str(part).strip().lower().replace("-", "_").replace(" ", "_")
+        for part in parts
+        if str(part).strip()
+    )
+
+
+__all__ = ["MDAnalysisResult", "plot_feature_traces", "plot_top_features", "run_mltsa"]

--- a/src/mltsa/md/export.py
+++ b/src/mltsa/md/export.py
@@ -1,0 +1,72 @@
+"""Export helpers for labeled MD state structures."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Sequence
+
+import h5py
+import numpy as np
+
+from mltsa.io.h5 import open_h5
+from mltsa.io.schema import results_experiment_path
+
+from .label import STATE_ORDER, SnapshotModel, _export_snapshots, _import_mdtraj, _load_trajectory
+
+
+def export_state_structures(
+    *,
+    h5_path: str | Path,
+    experiment_id: str,
+    output_dir: str | Path,
+    replica_ids: Sequence[str] | None = None,
+    center: bool = False,
+    align_protein: bool = False,
+) -> dict[str, Path]:
+    """Export multi-model PDB snapshots for previously labeled MD states."""
+
+    target_dir = Path(output_dir)
+    selected_replica_ids = None if replica_ids is None else {str(value) for value in replica_ids}
+    snapshots: list[SnapshotModel] = []
+
+    with open_h5(h5_path, "r") as handle:
+        entries_group = handle.get(f"{results_experiment_path(experiment_id)}/trajectory_labels/entries", default=None)
+        if not isinstance(entries_group, h5py.Group):
+            raise ValueError(
+                f"Could not find stored MD labels for experiment {experiment_id!r}. "
+                "Run label_trajectories(...) first."
+            )
+
+        md = _import_mdtraj()
+        for child in entries_group.values():
+            if not isinstance(child, h5py.Group):
+                continue
+            replica_id = str(child.attrs["replica_id"])
+            if selected_replica_ids is not None and replica_id not in selected_replica_ids:
+                continue
+
+            trajectory = _load_trajectory(
+                md,
+                Path(str(child.attrs["trajectory_path"])),
+                Path(str(child.attrs["topology_path"])),
+            )
+            topology = getattr(trajectory, "topology", getattr(trajectory, "top", None))
+            if topology is None:
+                raise TypeError("Loaded trajectory does not expose a topology object.")
+
+            snapshots.append(
+                SnapshotModel(
+                    label=str(child.attrs["state_label"]),
+                    xyz=np.asarray(trajectory.xyz[-1], dtype=np.float64),
+                    topology=topology,
+                    trajectory_path=str(child.attrs["trajectory_path"]),
+                    replica_id=replica_id,
+                )
+            )
+
+    snapshot_paths = {state: target_dir / f"{state}.pdb" for state in STATE_ORDER}
+    _export_snapshots(snapshots=snapshots, snapshot_paths=snapshot_paths, center=center, align_protein=align_protein)
+    return snapshot_paths
+
+
+__all__ = ["export_state_structures"]

--- a/tests/test_md_analyze.py
+++ b/tests/test_md_analyze.py
@@ -1,0 +1,235 @@
+"""Tests for the MD analysis workflow and thin CLI wrappers."""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from mltsa.io.h5 import open_h5
+from mltsa.io.schema import results_experiment_path
+from mltsa.md import featurize_dataset, label_trajectories, run_mltsa
+from mltsa.cli.main import main as root_cli_main
+from mltsa.cli.md import main as md_cli_main
+
+from ._md_fakes import FakeMdtraj, build_fake_md_module, make_xyz, register_fake_inputs
+
+
+@pytest.fixture()
+def fake_md_module() -> FakeMdtraj:
+    """Provide a fake mdtraj module with a reusable topology."""
+
+    return build_fake_md_module()
+
+
+def test_run_mltsa_uses_selected_feature_set(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """run_mltsa should load and analyze only the requested feature set."""
+
+    dataset_h5 = _build_md_feature_file(monkeypatch, workspace_tmp_dir, fake_md_module)
+    featurize_dataset(
+        h5_path=dataset_h5,
+        feature_set="pca_set",
+        feature_type="pca_xyz",
+        label_experiment_id="labels",
+        pca_components=2,
+    )
+
+    result = run_mltsa(
+        dataset_h5,
+        "pca_set",
+        model="random_forest",
+        model_kwargs={"n_estimators": 8, "max_depth": 2},
+    )
+
+    assert result.dataset.feature_set == "pca_set"
+    assert result.dataset.feature_type == "pca_xyz"
+    assert result.analysis_feature_names[:2] == ("pc_000@t000", "pc_001@t000")
+    assert result.predictions.shape == result.y.shape
+
+
+def test_run_mltsa_end_to_end_and_save_results(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> None:
+    """A small end-to-end MD analysis should train, explain, and persist results."""
+
+    dataset_h5 = _build_md_feature_file(monkeypatch, workspace_tmp_dir, fake_md_module)
+    results_h5 = workspace_tmp_dir / "analysis_results.h5"
+
+    result = run_mltsa(
+        dataset_h5,
+        "closest",
+        model="random_forest",
+        model_kwargs={"n_estimators": 12, "max_depth": 3},
+        explanation_method="native",
+        results_h5_path=results_h5,
+        experiment_id="md_demo",
+    )
+
+    assert result.training_score >= 0.5
+    assert result.explanation.method == "native"
+    assert result.analysis_path is not None
+    assert result.explanation_path is not None
+
+    with open_h5(results_h5, "r") as handle:
+        analysis_group = handle[f"{results_experiment_path('md_demo')}/analyses/analysis_0000"]
+        explanation_group = handle[f"{results_experiment_path('md_demo')}/explanations/explanation_0000"]
+        np.testing.assert_array_equal(analysis_group["y_true"][...], result.y)
+        np.testing.assert_array_equal(analysis_group["y_pred"][...], result.predictions)
+        assert explanation_group.attrs["method"] == "native"
+
+
+def test_cli_argument_parsing_and_dispatch(monkeypatch, workspace_tmp_dir: Path, capsys) -> None:
+    """The MD CLI should stay a thin wrapper over the Python API."""
+
+    calls: dict[str, dict[str, object]] = {}
+
+    def fake_label(**kwargs):
+        calls["label"] = kwargs
+        return SimpleNamespace(
+            processed=(object(),),
+            skipped_entry_keys=(),
+            overwritten_entry_keys=(),
+        )
+
+    def fake_build(**kwargs):
+        calls["build"] = kwargs
+        return SimpleNamespace(
+            feature_set="feat",
+            n_replicas=2,
+            n_frames=4,
+            n_features=3,
+        )
+
+    def fake_analyze(*args, **kwargs):
+        calls["analyze"] = {"args": args, "kwargs": kwargs}
+        return SimpleNamespace(
+            model_name="random_forest",
+            training_score=0.75,
+            explanation=SimpleNamespace(n_features=8),
+        )
+
+    monkeypatch.setattr("mltsa.cli.md.label_trajectories", fake_label)
+    monkeypatch.setattr("mltsa.cli.md.featurize_dataset", fake_build)
+    monkeypatch.setattr("mltsa.cli.md.run_mltsa", fake_analyze)
+
+    assert (
+        md_cli_main(
+            [
+                "label",
+                "--h5",
+                str(workspace_tmp_dir / "labels.h5"),
+                "--experiment",
+                "exp",
+                "--topology",
+                str(workspace_tmp_dir / "topology.pdb"),
+                "--trajectory",
+                str(workspace_tmp_dir / "traj_a.dcd"),
+                "--rule",
+                "sum_distances",
+                "--selection-pair",
+                "index 0",
+                "index 2",
+                "--lower-threshold",
+                "1.0",
+                "--upper-threshold",
+                "2.0",
+                "--window-size",
+                "3",
+            ]
+        )
+        == 0
+    )
+    assert calls["label"]["experiment_id"] == "exp"
+    captured = capsys.readouterr()
+    assert "Labeled" in captured.out
+
+    assert (
+        md_cli_main(
+            [
+                "build",
+                "--h5",
+                str(workspace_tmp_dir / "dataset.h5"),
+                "--feature-set",
+                "feat",
+                "--feature-type",
+                "pca_xyz",
+                "--label-experiment",
+                "labels",
+            ]
+        )
+        == 0
+    )
+    assert calls["build"]["feature_type"] == "pca_xyz"
+
+    assert (
+        md_cli_main(
+            [
+                "analyze",
+                "--h5",
+                str(workspace_tmp_dir / "dataset.h5"),
+                "--feature-set",
+                "feat",
+                "--model",
+                "rf",
+                "--model-kwarg",
+                "n_estimators=5",
+                "--explain",
+                "native",
+                "--results-h5",
+                str(workspace_tmp_dir / "results.h5"),
+            ]
+        )
+        == 0
+    )
+    assert calls["analyze"]["kwargs"]["model"] == "rf"
+    assert calls["analyze"]["kwargs"]["model_kwargs"] == {"n_estimators": 5}
+
+    delegated: list[list[str]] = []
+    root_cli_module = importlib.import_module("mltsa.cli.main")
+    monkeypatch.setattr(root_cli_module.md_cli, "main", lambda argv=None: delegated.append(list(argv or [])) or 0)
+    assert root_cli_main(["md", "analyze", "--h5", "dataset.h5", "--feature-set", "feat"]) == 0
+    assert delegated == [["analyze", "--h5", "dataset.h5", "--feature-set", "feat"]]
+
+
+def _build_md_feature_file(monkeypatch, workspace_tmp_dir: Path, fake_md_module: FakeMdtraj) -> Path:
+    """Create a small labeled and featurized MD HDF5 for analysis tests."""
+
+    topology_path, trajectory_paths = register_fake_inputs(
+        workspace_tmp_dir,
+        fake_md_module,
+        {
+            "traj_in_a": make_xyz([0.15, 0.20, 0.25, 0.30]),
+            "traj_in_b": make_xyz([0.25, 0.30, 0.35, 0.40]),
+            "traj_out_a": make_xyz([2.00, 2.10, 2.20, 2.30]),
+            "traj_out_b": make_xyz([2.20, 2.30, 2.40, 2.50]),
+        },
+    )
+    monkeypatch.setattr("mltsa.md.label._import_mdtraj", lambda: fake_md_module)
+    monkeypatch.setattr("mltsa.md.featurize._import_mdtraj", lambda: fake_md_module)
+
+    h5_path = workspace_tmp_dir / "md_dataset.h5"
+    label_trajectories(
+        trajectory_paths=[
+            trajectory_paths["traj_in_a"],
+            trajectory_paths["traj_in_b"],
+            trajectory_paths["traj_out_a"],
+            trajectory_paths["traj_out_b"],
+        ],
+        topology=topology_path,
+        h5_path=h5_path,
+        experiment_id="labels",
+        rule="sum_distances",
+        selection_pairs=[("index 0", "index 2")],
+        lower_threshold=0.8,
+        upper_threshold=1.5,
+        window_size=2,
+        replica_ids=["rep_in_a", "rep_in_b", "rep_out_a", "rep_out_b"],
+    )
+    featurize_dataset(
+        h5_path=h5_path,
+        feature_set="closest",
+        feature_type="closest_residue_distances",
+        label_experiment_id="labels",
+    )
+    return h5_path


### PR DESCRIPTION
## Summary

This PR adds the first MD analysis orchestration layer for the new `mltsa` package, together with a thin command-line interface.

It allows users to:
- load one selected MD feature set from an HDF5 dataset
- train a supported model on that feature set
- compute feature importances through the explainability layer
- save analysis outputs to a separate results HDF5
- run the same workflow through lightweight CLI commands

## Changes

- add `mltsa.md.analyze`
  - `run_mltsa(...)`
  - `plot_top_features(...)`
  - `plot_feature_traces(...)`
  - `MDAnalysisResult`

- add `mltsa.md.export`
  - `export_state_structures(...)` for exporting previously labeled state snapshots from stored MD results

- update `mltsa.md`
  - export the new analysis and export helpers from the public MD API

- add a thin MD CLI in `mltsa.cli.md`
  - `mltsa-md label`
  - `mltsa-md build`
  - `mltsa-md analyze`

- update the root CLI
  - support `mltsa md ...` as a thin delegate to the MD-specific CLI

- add a dedicated console entry point
  - `mltsa-md`

## Workflow behavior

`run_mltsa(...)` now:
- loads a selected MD feature set from an existing MD dataset HDF5
- prepares a model-ready analysis matrix from the stored feature set
- builds a model by name or accepts an existing model object
- fits the model and predicts on the loaded dataset
- computes an explanation method through the shared explainability API
- optionally saves analysis outputs and explanation results to a separate results HDF5

The CLI stays intentionally thin and calls the same Python APIs directly rather than duplicating business logic.

## Testing

Added tests for:
- loading a selected feature set into the MD analysis layer
- a small end-to-end analysis on toy MD data
- CLI argument parsing and basic command dispatch

Test command:
- `C:\Users\pedro\projects\GAP\.conda\python.exe -m pytest`

Result:
- `31 passed`

## Notes

- this milestone does not add time-resolved sliding-window analysis
- this milestone does not add PyMOL session generation
- MD runtime still uses lazy `mdtraj` imports, while tests continue to use the mocked mdtraj shim in this environment
